### PR TITLE
Add Standalone Subset for Single PC Deployment

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,279 @@
+# Claude Conductor - Quick Start Guide
+
+手軽に単一のPCでClaude Conductorを試すためのガイドです。
+
+## 🚀 ワンコマンドインストール
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/ootakazuhiko/claude-conductor.git
+cd claude-conductor
+
+# スタンドアロン版ブランチに切り替え
+git checkout feature/standalone-subset
+
+# インストールと起動
+./quick-start.sh
+```
+
+これだけで完了です！ダッシュボードが http://localhost:8080 で利用可能になります。
+
+## 📋 システム要件
+
+- **Python 3.10+** (推奨: 3.11)
+- **メモリ**: 最低2GB、推奨4GB
+- **ディスク**: 最低1GB空き容量
+- **OS**: Linux、macOS、Windows (WSL2)
+
+### オプション要件
+- **Docker/Podman**: コンテナモード使用時
+- **Git**: ソースコードのクローン用
+
+## 🎯 使用方法
+
+### 基本コマンド
+
+```bash
+# システム開始
+conductor start
+
+# コンテナモードで開始
+conductor start-container
+
+# 状態確認
+conductor status
+
+# ダッシュボードを開く
+conductor dashboard
+
+# テスト実行
+conductor test
+
+# システム停止
+conductor stop
+```
+
+### Webダッシュボード
+
+1. ブラウザで http://localhost:8080 にアクセス
+2. 右側の「Submit Task」でタスクを送信
+3. リアルタイムでエージェントの状態を監視
+
+## 📁 ディレクトリ構造
+
+```
+~/.claude-conductor/
+├── config/           # 設定ファイル
+│   └── config.yaml
+├── workspace/        # 作業ディレクトリ
+├── logs/            # ログファイル
+├── venv/            # Python仮想環境
+└── conductor        # CLIツール
+```
+
+## ⚙️ 設定のカスタマイズ
+
+### エージェント数の変更
+
+```yaml
+# ~/.claude-conductor/config/config.yaml
+num_agents: 3        # デフォルト: 2
+max_workers: 6       # デフォルト: 4
+```
+
+### リソース制限の調整
+
+```yaml
+container_config:
+  memory_limit: "2g"   # デフォルト: 1g
+  cpu_limit: "1.0"     # デフォルト: 0.5
+```
+
+### ポート番号の変更
+
+```yaml
+network:
+  dashboard_port: 8080  # Webダッシュボード
+  api_port: 8081       # API (オプション)
+```
+
+## 🧪 サンプルタスク
+
+### 1. 基本的なコマンド実行
+
+```bash
+# Webダッシュボードから送信
+Task Type: Generic
+Description: echo "Hello, Claude Conductor!"
+Priority: 5
+```
+
+### 2. ファイル解析
+
+```bash
+# まずサンプルファイルを作成
+echo "def hello(): print('Hello')" > ~/.claude-conductor/workspace/sample.py
+
+# Webダッシュボードから送信  
+Task Type: Code Review
+Description: Review Python code
+Files: sample.py
+Priority: 7
+```
+
+### 3. CLIからのテスト
+
+```bash
+# 基本テスト
+conductor test
+
+# カスタムタスクの作成 (Python)
+python3 -c "
+from conductor import create_task, Orchestrator
+task = create_task(
+    task_type='analysis',
+    description='Analyze project structure', 
+    priority=6
+)
+print(f'Task created: {task.task_id}')
+"
+```
+
+## 🐳 Dockerモード
+
+### 基本的な使用
+
+```bash
+# Docker Composeで起動
+docker-compose -f docker-compose.standalone.yml up
+
+# バックグラウンドで起動
+docker-compose -f docker-compose.standalone.yml up -d
+
+# 停止
+docker-compose -f docker-compose.standalone.yml down
+```
+
+### ファイルサーバー付きで起動
+
+```bash
+# Webベースのファイルブラウザも起動
+docker-compose -f docker-compose.standalone.yml --profile files up
+
+# ファイルアクセス: http://localhost:8090
+```
+
+## 🔧 トラブルシューティング
+
+### よくある問題
+
+1. **ポート8080が使用中**
+   ```bash
+   # ポート確認
+   lsof -i :8080
+   
+   # 設定変更
+   conductor config
+   # dashboard_port: 8888 に変更
+   ```
+
+2. **Pythonバージョンエラー**
+   ```bash
+   # Pythonバージョン確認
+   python3 --version
+   
+   # 要求: Python 3.10+
+   ```
+
+3. **メモリ不足**
+   ```bash
+   # 設定でエージェント数を削減
+   conductor config
+   # num_agents: 1 に変更
+   ```
+
+### ログの確認
+
+```bash
+# リアルタイムログ
+conductor logs
+
+# 詳細ログファイル
+tail -f ~/.claude-conductor/logs/*.log
+
+# エラーログのみ
+grep ERROR ~/.claude-conductor/logs/*.log
+```
+
+### 完全な再インストール
+
+```bash
+# 停止
+conductor stop
+
+# アンインストール
+./quick-start.sh uninstall
+
+# 再インストール
+./quick-start.sh install
+```
+
+## 📊 パフォーマンスチューニング
+
+### 軽量設定 (低スペックPC向け)
+
+```yaml
+num_agents: 1
+max_workers: 2
+container_config:
+  memory_limit: "512m"
+  cpu_limit: "0.25"
+```
+
+### 高性能設定 (高スペックPC向け)
+
+```yaml
+num_agents: 4
+max_workers: 8
+container_config:
+  memory_limit: "4g" 
+  cpu_limit: "2.0"
+```
+
+## 🔒 セキュリティ
+
+スタンドアロン版は**ローカル専用**として設計されています：
+
+- APIは127.0.0.1のみでリッスン
+- 認証は無効化
+- HTTPSは無効化
+- 外部ネットワークアクセス制限
+
+**本番環境では使用しないでください。**
+
+## 🚀 次のステップ
+
+1. **本格運用**: メインブランチのフル機能版を検討
+2. **クラスタ展開**: Kubernetes設定を利用
+3. **カスタム拡張**: エージェントの追加やカスタムタスクタイプ
+4. **監視強化**: Prometheus + Grafana統合
+
+## 📚 参考資料
+
+- **メインドキュメント**: `README.md`
+- **設定リファレンス**: `config/standalone.yaml`
+- **API文書**: http://localhost:8080/docs (起動後)
+- **ログ形式**: `~/.claude-conductor/logs/`
+
+## 💬 サポート
+
+問題が発生した場合：
+
+1. `conductor status` で状態確認
+2. `conductor logs` でログ確認  
+3. GitHubでIssue報告
+4. `./quick-start.sh uninstall` で完全削除
+
+---
+
+**重要**: これはスタンドアロン版です。本格的な本番環境利用には、メインブランチのフル機能版をご利用ください。

--- a/README.standalone.md
+++ b/README.standalone.md
@@ -1,0 +1,357 @@
+# Claude Conductor - Standalone Subset
+
+単一PCで手軽にClaude Conductorを試すためのサブセット版です。
+
+## 🎯 概要
+
+この`feature/standalone-subset`ブランチは、以下のような方に最適です：
+
+- **Claude Conductorを手軽に試したい**
+- **単一PCでの軽量運用**
+- **開発・学習目的での利用**
+- **複雑な設定なしでの実行**
+
+## 🚀 インストール方法
+
+### 方法1: フル機能版（推奨）
+
+```bash
+# リポジトリクローン
+git clone https://github.com/ootakazuhiko/claude-conductor.git
+cd claude-conductor
+
+# スタンドアロンブランチに切り替え
+git checkout feature/standalone-subset
+
+# ワンコマンドセットアップ
+./quick-start.sh
+```
+
+### 方法2: 超簡単版
+
+```bash
+# 最小限のデモ版
+curl -sSL https://raw.githubusercontent.com/ootakazuhiko/claude-conductor/feature/standalone-subset/simple-setup.sh | bash
+```
+
+## 🎮 使用方法
+
+### フル機能版の場合
+
+```bash
+# システム起動
+conductor start
+
+# Webダッシュボード
+conductor dashboard  # http://localhost:8080
+
+# テスト実行
+conductor test
+
+# システム停止
+conductor stop
+```
+
+### Dockerモードの場合
+
+```bash
+# Docker Composeで起動
+docker-compose -f docker-compose.standalone.yml up
+
+# ファイルサーバー付き
+docker-compose -f docker-compose.standalone.yml --profile files up
+```
+
+## 📊 機能比較
+
+| 機能 | Standalone版 | Full版 |
+|------|-------------|--------|
+| 基本オーケストレーション | ✅ | ✅ |
+| Webダッシュボード | ✅ | ✅ |
+| コンテナ統合 | ✅ | ✅ |
+| エージェント数 | 1-4 | 無制限 |
+| Redis統合 | ❌ | ✅ |
+| Kubernetes | ❌ | ✅ |
+| 監視・メトリクス | 基本のみ | 完全 |
+| クラスタ機能 | ❌ | ✅ |
+| 認証・セキュリティ | 無効 | 完全 |
+
+## 📁 ディレクトリ構造
+
+```
+~/.claude-conductor/               # インストールディレクトリ
+├── conductor*                     # CLIツール
+├── config/
+│   └── config.yaml               # 設定ファイル
+├── workspace/                    # 作業ディレクトリ
+├── logs/                        # ログファイル
+├── venv/                        # Python仮想環境
+├── start-local.sh*              # ローカル起動
+├── start-container.sh*          # コンテナ起動
+├── stop.sh*                     # 停止スクリプト
+└── README.md                    # 詳細ドキュメント
+```
+
+## ⚙️ 設定
+
+### 基本設定 (`config/config.yaml`)
+
+```yaml
+# エージェント数（1-4推奨）
+num_agents: 2
+
+# 同時実行数
+max_workers: 4
+
+# タスクタイムアウト（秒）
+task_timeout: 120
+
+# ログレベル
+log_level: "INFO"
+
+# リソース制限
+container_config:
+  memory_limit: "1g"
+  cpu_limit: "0.5"
+```
+
+### 軽量設定例
+
+```yaml
+num_agents: 1
+max_workers: 2
+container_config:
+  memory_limit: "512m"
+  cpu_limit: "0.25"
+```
+
+## 🧪 サンプルタスク
+
+### 1. 基本コマンド
+
+```bash
+# Webダッシュボードから実行
+Task Type: Generic
+Description: echo "Hello, Claude Conductor!"
+Priority: 5
+```
+
+### 2. Pythonスクリプト実行例
+
+```bash
+# ファイル作成
+echo 'print("Hello from Python!")' > ~/.claude-conductor/workspace/hello.py
+
+# タスク実行
+Task Type: Generic  
+Description: python3 hello.py
+Files: hello.py
+```
+
+### 3. CLIからの例
+
+```bash
+# サンプル実行
+python3 examples/standalone_examples.py
+
+# カスタムタスク
+python3 -c "
+from conductor import create_task
+task = create_task(
+    task_type='generic',
+    description='date && hostname',
+    priority=5
+)
+print(f'Task ID: {task.task_id}')
+"
+```
+
+## 🐳 Docker使用例
+
+### 基本起動
+
+```bash
+docker-compose -f docker-compose.standalone.yml up
+```
+
+### バックグラウンド起動
+
+```bash
+docker-compose -f docker-compose.standalone.yml up -d
+```
+
+### ファイルブラウザ付き
+
+```bash
+docker-compose -f docker-compose.standalone.yml --profile files up
+# ファイルアクセス: http://localhost:8090
+```
+
+### ログ確認
+
+```bash
+docker-compose -f docker-compose.standalone.yml logs -f
+```
+
+## 🔧 トラブルシューティング
+
+### よくある問題
+
+1. **ポート競合**
+   ```bash
+   # ポート8080が使用中の場合
+   conductor config
+   # dashboard_port: 8888 に変更
+   ```
+
+2. **メモリ不足**
+   ```bash
+   # エージェント数を削減
+   conductor config
+   # num_agents: 1 に変更
+   ```
+
+3. **Python環境エラー**
+   ```bash
+   # 仮想環境の再作成
+   conductor stop
+   rm -rf ~/.claude-conductor/venv
+   ./quick-start.sh
+   ```
+
+### ログ確認
+
+```bash
+# リアルタイムログ
+conductor logs
+
+# エラーログのみ
+grep ERROR ~/.claude-conductor/logs/*.log
+
+# 詳細ログ
+tail -f ~/.claude-conductor/logs/*.log
+```
+
+### 完全リセット
+
+```bash
+# 完全アンインストール
+./quick-start.sh uninstall
+
+# または手動削除
+rm -rf ~/.claude-conductor
+```
+
+## 🚀 パフォーマンス設定
+
+### 低スペックPC (2GB RAM)
+
+```yaml
+num_agents: 1
+max_workers: 2
+container_config:
+  memory_limit: "512m"
+  cpu_limit: "0.25"
+```
+
+### 中スペックPC (4GB RAM)
+
+```yaml
+num_agents: 2
+max_workers: 4
+container_config:
+  memory_limit: "1g"
+  cpu_limit: "0.5"
+```
+
+### 高スペックPC (8GB+ RAM)
+
+```yaml
+num_agents: 4
+max_workers: 8
+container_config:
+  memory_limit: "2g"
+  cpu_limit: "1.0"
+```
+
+## 🔒 セキュリティについて
+
+⚠️ **重要**: この版は**ローカル開発・テスト専用**です。
+
+- 認証機能は無効
+- HTTPSは無効
+- 外部アクセス制限
+- セキュリティ機能は最小限
+
+**本番環境では絶対に使用しないでください。**
+
+## 📈 本格運用への移行
+
+Standalone版で満足できたら、以下を検討してください：
+
+### 1. Full版への移行
+
+```bash
+# メインブランチに切り替え
+git checkout main
+
+# フル機能でセットアップ
+./setup.py install
+```
+
+### 2. クラウド展開
+
+```bash
+# Kubernetes展開
+kubectl apply -k k8s/
+
+# Docker Swarm展開
+docker stack deploy -c docker-compose.yml conductor
+```
+
+### 3. 監視・ロギング
+
+```bash
+# Prometheus + Grafana
+docker-compose --profile monitoring up
+
+# ELK Stack統合
+# 詳細は docs/monitoring.md を参照
+```
+
+## 🆚 他のオーケストレーターとの比較
+
+| 特徴 | Claude Conductor | Airflow | Prefect |
+|------|-----------------|---------|---------|
+| 学習コストの低さ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| セットアップの簡単さ | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| Claude統合 | ⭐⭐⭐⭐⭐ | ❌ | ❌ |
+| 軽量性 | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| エンタープライズ機能 | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
+
+## 📚 参考資料
+
+- **完全ドキュメント**: [README.md](README.md)
+- **クイックスタート**: [QUICK_START.md](QUICK_START.md)
+- **サンプルコード**: [examples/](examples/)
+- **設定リファレンス**: [config/standalone.yaml](config/standalone.yaml)
+
+## 💬 コミュニティ・サポート
+
+- **GitHub Issues**: バグ報告・機能要望
+- **GitHub Discussions**: 使用方法・ベストプラクティス
+- **Examples**: `examples/standalone_examples.py`
+
+## 📄 ライセンス
+
+MIT License - 商用・非商用問わず自由に利用可能
+
+---
+
+**🎯 まずは試してみましょう！**
+
+```bash
+./quick-start.sh && conductor start
+```
+
+ダッシュボード: http://localhost:8080

--- a/config/standalone.yaml
+++ b/config/standalone.yaml
@@ -1,0 +1,134 @@
+# Claude Conductor - Standalone Configuration
+# Optimized for single PC deployment with minimal resource usage
+
+# Core settings
+num_agents: 2
+max_workers: 4
+task_timeout: 120
+log_level: "INFO"
+
+# Agent configuration - lightweight settings
+agent_config:
+  startup_delay: 5  # seconds
+  health_check_interval: 30
+  max_memory_usage: "1g"
+  max_cpu_usage: "0.5"
+
+# Container configuration - reduced resource requirements
+container_config:
+  image: "ubuntu:22.04"
+  memory_limit: "1g"
+  cpu_limit: "0.5"
+  enable_networking: false  # Disable container networking for simplicity
+  workspace_mount: true
+
+# Storage configuration
+storage:
+  workspace_path: "~/.claude-conductor/workspace"
+  logs_path: "~/.claude-conductor/logs"
+  config_path: "~/.claude-conductor/config"
+  temp_path: "/tmp/claude-conductor"
+  max_log_size: "100MB"
+  log_rotation_count: 3
+
+# Network configuration
+network:
+  dashboard_port: 8080
+  api_port: 8081
+  bind_address: "127.0.0.1"  # Local only for security
+  enable_cors: false
+  max_connections: 10
+
+# Feature toggles - disable complex features for standalone
+features:
+  redis_enabled: false
+  monitoring_enabled: false
+  clustering_enabled: false
+  auto_scaling_enabled: false
+  metrics_collection: true
+  web_dashboard: true
+  agent_communication: true
+
+# Performance settings
+performance:
+  thread_pool_size: 4
+  queue_max_size: 100
+  task_batch_size: 5
+  enable_caching: true
+  cache_ttl: 300  # 5 minutes
+
+# Development/testing settings
+development:
+  mock_claude_code: true  # Use mock Claude Code CLI
+  enable_debug_logs: false
+  auto_restart_agents: true
+  simulate_task_execution: false
+
+# Security settings (basic for standalone)
+security:
+  enable_authentication: false
+  enable_https: false
+  api_key_required: false
+  cors_origins: ["http://localhost:8080"]
+
+# Task execution settings
+task_execution:
+  default_priority: 5
+  max_retries: 2
+  retry_delay: 5  # seconds
+  parallel_execution: true
+  timeout_buffer: 10  # seconds
+
+# Logging configuration
+logging:
+  format: "%(asctime)s [%(levelname)8s] %(name)s: %(message)s"
+  date_format: "%Y-%m-%d %H:%M:%S"
+  console_output: true
+  file_output: true
+  json_format: false
+  
+  loggers:
+    conductor.orchestrator:
+      level: "INFO"
+    conductor.agent:
+      level: "INFO"
+    conductor.protocol:
+      level: "WARNING"
+    conductor.utils:
+      level: "WARNING"
+
+# Dashboard configuration
+dashboard:
+  title: "Claude Conductor - Standalone"
+  auto_refresh_interval: 5  # seconds
+  max_log_entries: 100
+  enable_task_submission: true
+  enable_agent_management: false  # Simplified for standalone
+  theme: "light"
+
+# Notifications (disabled for standalone)
+notifications:
+  enabled: false
+  email_notifications: false
+  webhook_notifications: false
+
+# Backup and maintenance
+maintenance:
+  auto_cleanup_logs: true
+  log_retention_days: 7
+  workspace_cleanup: true
+  temp_file_cleanup: true
+  cleanup_interval: 3600  # 1 hour
+
+# Example tasks for testing
+example_tasks:
+  - task_type: "generic"
+    description: "echo 'Hello from Claude Conductor!'"
+    priority: 5
+  - task_type: "code_review"
+    description: "Review sample Python file"
+    files: ["example.py"]
+    priority: 7
+  - task_type: "analysis" 
+    description: "Analyze project structure"
+    priority: 6

--- a/containers/nginx-standalone.conf
+++ b/containers/nginx-standalone.conf
@@ -1,0 +1,59 @@
+server {
+    listen 80;
+    server_name localhost;
+    
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    
+    # Root directory
+    root /usr/share/nginx/html;
+    index index.html;
+    
+    # Enable directory listing
+    autoindex on;
+    autoindex_exact_size off;
+    autoindex_localtime on;
+    autoindex_format html;
+    
+    # Workspace access
+    location /workspace/ {
+        alias /usr/share/nginx/html/workspace/;
+        autoindex on;
+        
+        # Allow downloading files
+        location ~* \.(py|js|html|css|md|txt|json|yaml|yml|log)$ {
+            add_header Content-Disposition 'attachment';
+        }
+    }
+    
+    # Logs access
+    location /logs/ {
+        alias /usr/share/nginx/html/logs/;
+        autoindex on;
+        
+        # Log files
+        location ~* \.log$ {
+            add_header Content-Type "text/plain";
+        }
+    }
+    
+    # Default page
+    location = / {
+        return 301 /workspace/;
+    }
+    
+    # Security - deny access to hidden files
+    location ~ /\. {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+    
+    # Compress responses
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+}

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -1,0 +1,124 @@
+version: '3.8'
+
+# Claude Conductor - Standalone Docker Compose
+# Simplified single-machine deployment
+
+services:
+  # Main conductor service - lightweight configuration
+  conductor:
+    build:
+      context: .
+      dockerfile: containers/Dockerfile
+      target: production
+      args:
+        PYTHON_VERSION: "3.10"
+    container_name: claude-conductor-standalone
+    restart: unless-stopped
+    ports:
+      - "8080:8080"   # Web Dashboard
+      - "8081:8081"   # API (optional)
+    volumes:
+      - conductor_workspace:/workspace
+      - conductor_logs:/var/log/conductor
+      - conductor_config:/home/claude/.conductor
+      - ./config/standalone.yaml:/app/config/config.yaml:ro
+    environment:
+      - CONDUCTOR_MODE=standalone
+      - CONDUCTOR_LOG_LEVEL=INFO
+      - CONDUCTOR_CONFIG=/app/config/config.yaml
+      - CONDUCTOR_NUM_AGENTS=2
+      - CONDUCTOR_DASHBOARD_PORT=8080
+      # Standalone-specific settings
+      - CONDUCTOR_FEATURES_REDIS_ENABLED=false
+      - CONDUCTOR_FEATURES_MONITORING_ENABLED=false
+      - CONDUCTOR_FEATURES_CLUSTERING_ENABLED=false
+    networks:
+      - conductor-standalone
+    healthcheck:
+      test: ["CMD", "/healthcheck.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    command: ["full"]
+    # Resource limits for single PC
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+
+  # Optional: Redis for advanced features (commented out by default)
+  # redis:
+  #   image: redis:7-alpine
+  #   container_name: claude-conductor-redis
+  #   restart: unless-stopped
+  #   volumes:
+  #     - redis_data:/data
+  #   networks:
+  #     - conductor-standalone
+  #   command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+  #   deploy:
+  #     resources:
+  #       limits:
+  #         cpus: '0.5'
+  #         memory: 512M
+
+  # Optional: Simple file server for workspace access
+  file-server:
+    image: nginx:alpine
+    container_name: claude-conductor-files
+    restart: unless-stopped
+    ports:
+      - "8090:80"
+    volumes:
+      - conductor_workspace:/usr/share/nginx/html/workspace:ro
+      - conductor_logs:/usr/share/nginx/html/logs:ro
+      - ./containers/nginx-standalone.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - conductor-standalone
+    profiles:
+      - files
+    deploy:
+      resources:
+        limits:
+          cpus: '0.2'
+          memory: 128M
+
+volumes:
+  conductor_workspace:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${HOME}/.claude-conductor/workspace
+  conductor_logs:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind  
+      device: ${HOME}/.claude-conductor/logs
+  conductor_config:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${HOME}/.claude-conductor/config
+  # redis_data:
+  #   driver: local
+
+networks:
+  conductor-standalone:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24
+
+# Docker Compose profiles for different use cases
+# Usage:
+#   docker-compose -f docker-compose.standalone.yml up                    # Basic setup
+#   docker-compose -f docker-compose.standalone.yml --profile files up   # With file server
+#   docker-compose -f docker-compose.standalone.yml --profile redis up   # With Redis

--- a/docs/architecture-comparison.md
+++ b/docs/architecture-comparison.md
@@ -1,0 +1,254 @@
+# Claude Conductor - Architecture Comparison
+
+## 📊 Feature Comparison Matrix
+
+| Feature Category | Standalone | Docker Compose | Kubernetes (Full) |
+|-----------------|------------|----------------|-------------------|
+| **Deployment** |
+| Setup Time | 5 minutes | 10 minutes | 30+ minutes |
+| Setup Complexity | ⭐ | ⭐⭐ | ⭐⭐⭐⭐⭐ |
+| Required Skills | Basic CLI | Docker basics | K8s expertise |
+| **Scale** |
+| Agent Count | 1-4 | 1-10 | 1-1000+ |
+| Node Count | 1 | 1 | Unlimited |
+| Auto-scaling | ❌ | ❌ | ✅ |
+| **Resources** |
+| Min RAM | 2GB | 4GB | 16GB+ |
+| Min CPU | 1 core | 2 cores | 4+ cores |
+| Storage Type | Local files | Docker volumes | PVC/Cloud storage |
+| **Features** |
+| Web Dashboard | ✅ | ✅ | ✅ |
+| API Access | ✅ | ✅ | ✅ |
+| Task Queue | In-memory | Redis (optional) | Redis cluster |
+| Monitoring | Basic logs | Container logs | Full observability |
+| **Reliability** |
+| High Availability | ❌ | ❌ | ✅ |
+| Auto-recovery | Basic | Container restart | Full orchestration |
+| Backup/Restore | Manual | Volume backup | Automated |
+| **Security** |
+| Authentication | ❌ | Basic | Enterprise |
+| Encryption | ❌ | Optional | mTLS everywhere |
+| Network Isolation | Host only | Docker network | Network policies |
+
+## 🏗️ Architecture Patterns
+
+### 1. Standalone Pattern (開発・学習用)
+
+```
+┌─────────────────────────────────────┐
+│         Single Machine              │
+│  ┌─────────────────────────────┐   │
+│  │   Python Virtual Env        │   │
+│  │  ┌──────┐ ┌──────────┐    │   │
+│  │  │ CLI  │ │Dashboard │    │   │
+│  │  └──┬───┘ └────┬─────┘    │   │
+│  │     │          │           │   │
+│  │  ┌──▼──────────▼─────┐    │   │
+│  │  │   Orchestrator     │    │   │
+│  │  └──────┬───────────┘    │   │
+│  │         │                 │   │
+│  │  ┌──────▼────────┐       │   │
+│  │  │ Local Agents  │       │   │
+│  │  │   (1-4)       │       │   │
+│  │  └───────────────┘       │   │
+│  └─────────────────────────────┘   │
+│                                     │
+│  📁 ~/.claude-conductor/            │
+└─────────────────────────────────────┘
+```
+
+**Use Cases:**
+- 個人開発者の自動化ツール
+- Claude Conductorの学習・評価
+- 小規模なバッチ処理
+- プロトタイピング
+
+### 2. Container Pattern (小規模運用)
+
+```
+┌─────────────────────────────────────┐
+│         Docker Host                 │
+│  ┌─────────────────────────────┐   │
+│  │   Docker Compose Stack      │   │
+│  │  ┌──────────────────────┐  │   │
+│  │  │ conductor:latest     │  │   │
+│  │  │ ┌────┐ ┌─────────┐ │  │   │
+│  │  │ │Orch│ │Dashboard│ │  │   │
+│  │  │ └────┘ └─────────┘ │  │   │
+│  │  └──────────────────────┘  │   │
+│  │  ┌──────────────────────┐  │   │
+│  │  │ redis:alpine (opt)  │  │   │
+│  │  └──────────────────────┘  │   │
+│  │  ┌──────────────────────┐  │   │
+│  │  │ nginx:alpine (opt)  │  │   │
+│  │  └──────────────────────┘  │   │
+│  └─────────────────────────────┘   │
+│                                     │
+│  🔗 Volumes → Host filesystem      │
+└─────────────────────────────────────┘
+```
+
+**Use Cases:**
+- チーム開発環境
+- 小規模な本番運用
+- CI/CDパイプライン統合
+- 隔離された実行環境が必要な場合
+
+### 3. Kubernetes Pattern (エンタープライズ)
+
+```
+┌──────────────────────────────────────────┐
+│           Kubernetes Cluster             │
+│  ┌────────────────────────────────────┐ │
+│  │         Ingress Controller         │ │
+│  └────────────┬───────────────────────┘ │
+│               │                          │
+│  ┌────────────▼───────────────────────┐ │
+│  │      Application Namespace         │ │
+│  │  ┌─────────┐ ┌─────────┐ ┌──────┐│ │
+│  │  │Dashboard│ │   API   │ │ Orch ││ │
+│  │  │   Pod   │ │   Pod   │ │ Pod  ││ │
+│  │  └─────────┘ └─────────┘ └──────┘│ │
+│  │  ┌─────────────────────────────┐  │ │
+│  │  │    Agent ReplicaSet         │  │ │
+│  │  │  ┌───┐ ┌───┐ ┌───┐ ┌───┐ │  │ │
+│  │  │  │A1 │ │A2 │ │A3 │ │... │ │  │ │
+│  │  │  └───┘ └───┘ └───┘ └───┘ │  │ │
+│  │  └─────────────────────────────┘  │ │
+│  └────────────────────────────────────┘ │
+│  ┌────────────────────────────────────┐ │
+│  │         Data Services              │ │
+│  │  ┌──────┐ ┌──────┐ ┌───────────┐ │ │
+│  │  │Redis │ │ PG   │ │   S3      │ │ │
+│  │  └──────┘ └──────┘ └───────────┘ │ │
+│  └────────────────────────────────────┘ │
+│  ┌────────────────────────────────────┐ │
+│  │      Monitoring Stack              │ │
+│  │  ┌────────┐ ┌───────┐ ┌────────┐ │ │
+│  │  │Promeths│ │Grafana│ │ Loki   │ │ │
+│  │  └────────┘ └───────┘ └────────┘ │ │
+│  └────────────────────────────────────┘ │
+└──────────────────────────────────────────┘
+```
+
+**Use Cases:**
+- 大規模エンタープライズ環境
+- マルチテナント対応
+- 24/7高可用性が必要
+- コンプライアンス要件
+- グローバル分散デプロイ
+
+## 🔄 Migration Strategies
+
+### Phase 1: Standalone → Docker
+```bash
+# Export current configuration
+conductor config export > config.backup.yaml
+
+# Stop standalone
+conductor stop
+
+# Start with Docker Compose
+docker-compose -f docker-compose.standalone.yml up -d
+
+# Import configuration
+docker exec claude-conductor conductor config import < config.backup.yaml
+```
+
+### Phase 2: Docker → Kubernetes
+```bash
+# Build and push images
+docker build -t myregistry/claude-conductor:v1.0 .
+docker push myregistry/claude-conductor:v1.0
+
+# Update Kubernetes manifests
+sed -i 's|claudeconductor/claude-conductor:latest|myregistry/claude-conductor:v1.0|g' k8s/*.yaml
+
+# Deploy to Kubernetes
+kubectl create namespace claude-conductor
+kubectl apply -k k8s/
+```
+
+## 🎯 Decision Tree
+
+```mermaid
+graph TD
+    A[Start] -->|Personal Use?| B[Standalone]
+    A -->|Team Use?| C{Container Experience?}
+    A -->|Enterprise?| D[Kubernetes]
+    
+    C -->|Yes| E[Docker Compose]
+    C -->|No| B
+    
+    B -->|Need Isolation?| E
+    E -->|Need Scale?| D
+    
+    style A fill:#f9f,stroke:#333,stroke-width:4px
+    style B fill:#9f9,stroke:#333,stroke-width:2px
+    style E fill:#ff9,stroke:#333,stroke-width:2px
+    style D fill:#9ff,stroke:#333,stroke-width:2px
+```
+
+## 📈 Performance Characteristics
+
+### Standalone Performance
+- **Startup Time**: < 5 seconds
+- **Task Latency**: ~100ms
+- **Memory Usage**: 200-500MB
+- **CPU Usage**: 5-20%
+
+### Docker Performance
+- **Startup Time**: 10-30 seconds
+- **Task Latency**: ~150ms
+- **Memory Usage**: 500MB-2GB
+- **CPU Usage**: 10-30%
+
+### Kubernetes Performance
+- **Startup Time**: 1-5 minutes
+- **Task Latency**: ~200ms (with optimization: ~50ms)
+- **Memory Usage**: 2-10GB (cluster total)
+- **CPU Usage**: Variable with HPA
+
+## 🔧 Optimization Tips
+
+### For Standalone
+1. Reduce agent count for low-spec machines
+2. Use local SSD for workspace
+3. Disable unnecessary features
+4. Tune Python garbage collection
+
+### For Docker
+1. Use multi-stage builds
+2. Enable BuildKit caching
+3. Mount volumes for persistence
+4. Use resource limits
+
+### For Kubernetes
+1. Use node affinity for agents
+2. Enable pod disruption budgets
+3. Implement proper health checks
+4. Use horizontal pod autoscaling
+5. Configure resource requests/limits
+6. Use persistent volume claims
+7. Implement service mesh for security
+
+## 🚀 Quick Decision Guide
+
+Choose **Standalone** if:
+- ✅ Single user
+- ✅ Limited resources
+- ✅ Quick evaluation needed
+- ✅ No container experience
+
+Choose **Docker Compose** if:
+- ✅ Small team (< 10 users)
+- ✅ Need environment isolation
+- ✅ Want easy deployment
+- ✅ Have Docker experience
+
+Choose **Kubernetes** if:
+- ✅ Large organization
+- ✅ Need high availability
+- ✅ Require auto-scaling
+- ✅ Have K8s expertise
+- ✅ Need enterprise features

--- a/docs/architecture-diagrams.py
+++ b/docs/architecture-diagrams.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""
+Generate architecture diagrams for Claude Conductor
+Requires: pip install matplotlib networkx pygraphviz
+"""
+
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+from matplotlib.patches import FancyBboxPatch, Rectangle, Circle, FancyArrowPatch
+import numpy as np
+
+def create_standalone_architecture():
+    """Create standalone architecture diagram"""
+    fig, ax = plt.subplots(1, 1, figsize=(12, 10))
+    
+    # Define colors
+    colors = {
+        'ui': '#E3F2FD',
+        'core': '#FFF3E0',
+        'agent': '#E8F5E9',
+        'storage': '#F5F5F5',
+        'comm': '#FCE4EC'
+    }
+    
+    # Main container
+    main_box = FancyBboxPatch((0.5, 0.5), 11, 9,
+                              boxstyle="round,pad=0.1",
+                              facecolor='white',
+                              edgecolor='black',
+                              linewidth=2)
+    ax.add_patch(main_box)
+    ax.text(6, 9.7, 'Local Machine - Standalone Claude Conductor', 
+            ha='center', va='center', fontsize=16, fontweight='bold')
+    
+    # UI Layer
+    ui_box = FancyBboxPatch((1, 7.5), 4.5, 1.5,
+                            boxstyle="round,pad=0.05",
+                            facecolor=colors['ui'],
+                            edgecolor='darkblue')
+    ax.add_patch(ui_box)
+    ax.text(3.25, 8.6, 'User Interface', ha='center', fontweight='bold')
+    ax.text(2.25, 8.1, 'Web Browser\nlocalhost:8080', ha='center', fontsize=9)
+    ax.text(4.25, 8.1, 'CLI Tool\nconductor', ha='center', fontsize=9)
+    
+    # Core Layer
+    core_box = FancyBboxPatch((1, 5), 9.5, 2,
+                              boxstyle="round,pad=0.05",
+                              facecolor=colors['core'],
+                              edgecolor='darkorange')
+    ax.add_patch(core_box)
+    ax.text(5.75, 6.6, 'Claude Conductor Core', ha='center', fontweight='bold')
+    
+    # Core components
+    components = [
+        (2.5, 5.8, 'Orchestrator\nタスク管理'),
+        (5.75, 5.8, 'Web Dashboard\nFastAPI'),
+        (9, 5.8, 'API Server\nREST API')
+    ]
+    for x, y, text in components:
+        comp_box = Rectangle((x-0.7, y-0.3), 1.4, 0.6,
+                            facecolor='white',
+                            edgecolor='gray')
+        ax.add_patch(comp_box)
+        ax.text(x, y, text, ha='center', fontsize=8)
+    
+    # Agent Layer
+    agent_box = FancyBboxPatch((1, 2.5), 9.5, 2,
+                               boxstyle="round,pad=0.05",
+                               facecolor=colors['agent'],
+                               edgecolor='darkgreen')
+    ax.add_patch(agent_box)
+    ax.text(5.75, 4.1, 'Agent Pool (1-4 agents)', ha='center', fontweight='bold')
+    
+    # Agents
+    agents = [
+        (2.5, 3.3, 'Agent 1\nClaude Mock'),
+        (5.75, 3.3, 'Agent 2\nClaude Mock'),
+        (9, 3.3, 'Agent N\n(Optional)')
+    ]
+    for i, (x, y, text) in enumerate(agents):
+        style = 'dashed' if i == 2 else 'solid'
+        agent_circle = Circle((x, y), 0.6,
+                             facecolor='white' if i < 2 else '#F3E5F5',
+                             edgecolor='gray',
+                             linestyle=style)
+        ax.add_patch(agent_circle)
+        ax.text(x, y, text, ha='center', fontsize=8)
+    
+    # Storage Layer
+    storage_box = FancyBboxPatch((1, 0.5), 4.5, 1.5,
+                                 boxstyle="round,pad=0.05",
+                                 facecolor=colors['storage'],
+                                 edgecolor='gray')
+    ax.add_patch(storage_box)
+    ax.text(3.25, 1.6, 'Local Storage', ha='center', fontweight='bold')
+    
+    # Storage components
+    storages = [
+        (2, 0.9, 'Config\n(YAML)'),
+        (3.25, 0.9, 'Workspace\n(Files)'),
+        (4.5, 0.9, 'Logs\n(Text)')
+    ]
+    for x, y, text in storages:
+        storage_rect = Rectangle((x-0.35, y-0.2), 0.7, 0.4,
+                                facecolor='white',
+                                edgecolor='darkgray')
+        ax.add_patch(storage_rect)
+        ax.text(x, y, text, ha='center', fontsize=7)
+    
+    # Communication Layer
+    comm_box = FancyBboxPatch((6.5, 0.5), 4, 1.5,
+                              boxstyle="round,pad=0.05",
+                              facecolor=colors['comm'],
+                              edgecolor='darkred')
+    ax.add_patch(comm_box)
+    ax.text(8.5, 1.6, 'Communication', ha='center', fontweight='bold')
+    
+    # Communication components
+    comm_components = [
+        (7.5, 0.9, 'In-Memory Queue\nタスクキュー'),
+        (9.5, 0.9, 'Unix Socket\nエージェント通信')
+    ]
+    for x, y, text in comm_components:
+        comm_rect = Rectangle((x-0.5, y-0.2), 1, 0.4,
+                             facecolor='white',
+                             edgecolor='darkgray')
+        ax.add_patch(comm_rect)
+        ax.text(x, y, text, ha='center', fontsize=7)
+    
+    # Add arrows for data flow
+    # UI to Core
+    arrow1 = FancyArrowPatch((3.25, 7.5), (3.25, 7),
+                            connectionstyle="arc3,rad=0",
+                            arrowstyle='-|>',
+                            mutation_scale=20,
+                            linewidth=2,
+                            color='blue')
+    ax.add_patch(arrow1)
+    
+    # Core to Agents
+    arrow2 = FancyArrowPatch((5.75, 5), (5.75, 4.5),
+                            connectionstyle="arc3,rad=0",
+                            arrowstyle='<->',
+                            mutation_scale=20,
+                            linewidth=2,
+                            color='orange')
+    ax.add_patch(arrow2)
+    
+    # Core to Storage
+    arrow3 = FancyArrowPatch((3.25, 5), (3.25, 2),
+                            connectionstyle="arc3,rad=.3",
+                            arrowstyle='<->',
+                            mutation_scale=20,
+                            linewidth=1.5,
+                            color='gray')
+    ax.add_patch(arrow3)
+    
+    # Agents to Communication
+    arrow4 = FancyArrowPatch((8.5, 2.5), (8.5, 2),
+                            connectionstyle="arc3,rad=0",
+                            arrowstyle='<->',
+                            mutation_scale=20,
+                            linewidth=1.5,
+                            color='red')
+    ax.add_patch(arrow4)
+    
+    ax.set_xlim(0, 12)
+    ax.set_ylim(0, 10)
+    ax.axis('off')
+    
+    plt.title('Claude Conductor - Standalone Architecture', fontsize=18, pad=20)
+    plt.tight_layout()
+    
+    return fig
+
+def create_kubernetes_architecture():
+    """Create Kubernetes full architecture diagram"""
+    fig, ax = plt.subplots(1, 1, figsize=(16, 12))
+    
+    # Define colors
+    colors = {
+        'external': '#E1F5FE',
+        'ingress': '#FFCCBC',
+        'app': '#FFF3E0',
+        'data': '#FFEBEE',
+        'monitoring': '#F3E5F5',
+        'mesh': '#FCE4EC',
+        'storage': '#F5F5F5'
+    }
+    
+    # Main Kubernetes cluster box
+    cluster_box = FancyBboxPatch((0.5, 0.5), 15, 11,
+                                boxstyle="round,pad=0.1",
+                                facecolor='white',
+                                edgecolor='black',
+                                linewidth=3)
+    ax.add_patch(cluster_box)
+    ax.text(8, 11.2, 'Kubernetes Cluster - Production Claude Conductor', 
+            ha='center', va='center', fontsize=18, fontweight='bold')
+    
+    # External layer
+    external_y = 10
+    external_services = [
+        (2, external_y, 'Users/\nDevelopers'),
+        (5, external_y, 'GitHub\nRepository'),
+        (8, external_y, 'Docker Hub\nRegistry'),
+        (11, external_y, 'Cloud Provider\nAWS/GCP/Azure'),
+        (14, external_y, 'CI/CD\nGitHub Actions')
+    ]
+    
+    for x, y, text in external_services:
+        ext_box = FancyBboxPatch((x-0.8, y-0.4), 1.6, 0.8,
+                                boxstyle="round,pad=0.05",
+                                facecolor=colors['external'],
+                                edgecolor='darkblue')
+        ax.add_patch(ext_box)
+        ax.text(x, y, text, ha='center', fontsize=9)
+    
+    # Ingress layer
+    ingress_box = FancyBboxPatch((1, 8), 14, 1.2,
+                                boxstyle="round,pad=0.05",
+                                facecolor=colors['ingress'],
+                                edgecolor='darkorange')
+    ax.add_patch(ingress_box)
+    ax.text(8, 8.6, 'Ingress Layer', ha='center', fontweight='bold')
+    
+    ingress_components = [
+        (4, 8.3, 'NGINX Ingress\nLoad Balancer'),
+        (8, 8.3, 'TLS Termination\nHTTPS'),
+        (12, 8.3, 'Rate Limiting\nWAF')
+    ]
+    for x, y, text in ingress_components:
+        ing_rect = Rectangle((x-0.8, y-0.2), 1.6, 0.4,
+                            facecolor='white',
+                            edgecolor='gray')
+        ax.add_patch(ing_rect)
+        ax.text(x, y, text, ha='center', fontsize=8)
+    
+    # Application layer
+    app_box = FancyBboxPatch((1, 5), 7, 2.5,
+                            boxstyle="round,pad=0.05",
+                            facecolor=colors['app'],
+                            edgecolor='darkorange')
+    ax.add_patch(app_box)
+    ax.text(4.5, 7.2, 'Application Layer', ha='center', fontweight='bold')
+    
+    # Application pods
+    app_pods = [
+        (2.5, 6.5, 'Orchestrator\nStatefulSet'),
+        (4.5, 6.5, 'Dashboard\nDeployment'),
+        (6.5, 6.5, 'API Server\nDeployment')
+    ]
+    for x, y, text in app_pods:
+        pod_box = Rectangle((x-0.6, y-0.3), 1.2, 0.6,
+                           facecolor='white',
+                           edgecolor='gray')
+        ax.add_patch(pod_box)
+        ax.text(x, y, text, ha='center', fontsize=8)
+    
+    # Agent ReplicaSet
+    agent_box = Rectangle((2, 5.3), 5, 0.8,
+                         facecolor='#E8F5E9',
+                         edgecolor='darkgreen')
+    ax.add_patch(agent_box)
+    ax.text(4.5, 5.7, 'Agent ReplicaSet (3-10 replicas with HPA)', ha='center', fontsize=9)
+    
+    # Data layer
+    data_box = FancyBboxPatch((9, 5), 6, 2.5,
+                             boxstyle="round,pad=0.05",
+                             facecolor=colors['data'],
+                             edgecolor='darkred')
+    ax.add_patch(data_box)
+    ax.text(12, 7.2, 'Data Layer', ha='center', fontweight='bold')
+    
+    # Data services
+    data_services = [
+        (10, 6.5, 'Redis Cluster\nTask Queue'),
+        (12, 6.5, 'PostgreSQL\nMetadata'),
+        (14, 6.5, 'S3/MinIO\nObject Store')
+    ]
+    for x, y, text in data_services:
+        data_rect = Rectangle((x-0.6, y-0.3), 1.2, 0.6,
+                             facecolor='white',
+                             edgecolor='gray')
+        ax.add_patch(data_rect)
+        ax.text(x, y, text, ha='center', fontsize=8)
+    
+    # Service Mesh
+    mesh_box = FancyBboxPatch((1, 3.5), 7, 1,
+                             boxstyle="round,pad=0.05",
+                             facecolor=colors['mesh'],
+                             edgecolor='purple')
+    ax.add_patch(mesh_box)
+    ax.text(4.5, 4, 'Service Mesh (Istio/Linkerd) - mTLS, Tracing, Circuit Breaking', 
+            ha='center', fontsize=9)
+    
+    # Monitoring Stack
+    monitor_box = FancyBboxPatch((9, 2), 6, 2.5,
+                                boxstyle="round,pad=0.05",
+                                facecolor=colors['monitoring'],
+                                edgecolor='purple')
+    ax.add_patch(monitor_box)
+    ax.text(12, 4.2, 'Monitoring Stack', ha='center', fontweight='bold')
+    
+    # Monitoring components
+    monitor_components = [
+        (10, 3.5, 'Prometheus\nMetrics'),
+        (12, 3.5, 'Grafana\nDashboards'),
+        (14, 3.5, 'Loki\nLogs'),
+        (10, 2.5, 'Jaeger\nTracing'),
+        (12, 2.5, 'AlertManager\nAlerts'),
+        (14, 2.5, 'PagerDuty\nIncidents')
+    ]
+    for x, y, text in monitor_components:
+        mon_rect = Rectangle((x-0.5, y-0.2), 1, 0.4,
+                            facecolor='white',
+                            edgecolor='gray')
+        ax.add_patch(mon_rect)
+        ax.text(x, y, text, ha='center', fontsize=7)
+    
+    # Storage layer
+    storage_box = FancyBboxPatch((1, 0.8), 7, 1,
+                                boxstyle="round,pad=0.05",
+                                facecolor=colors['storage'],
+                                edgecolor='gray')
+    ax.add_patch(storage_box)
+    ax.text(4.5, 1.3, 'Persistent Storage', ha='center', fontweight='bold')
+    
+    storage_pvcs = [
+        (2.5, 1, 'PVC: Workspace\nReadWriteMany'),
+        (4.5, 1, 'PVC: Logs\nReadWriteMany'),
+        (6.5, 1, 'PVC: Config\nReadWriteOnce')
+    ]
+    for x, y, text in storage_pvcs:
+        pvc_rect = Rectangle((x-0.6, y-0.15), 1.2, 0.3,
+                            facecolor='white',
+                            edgecolor='darkgray')
+        ax.add_patch(pvc_rect)
+        ax.text(x, y, text, ha='center', fontsize=7)
+    
+    # Add connection arrows
+    # External to Ingress
+    arrow1 = FancyArrowPatch((8, 9.5), (8, 9.2),
+                            connectionstyle="arc3,rad=0",
+                            arrowstyle='-|>',
+                            mutation_scale=25,
+                            linewidth=3,
+                            color='blue')
+    ax.add_patch(arrow1)
+    
+    # Ingress to App
+    arrow2 = FancyArrowPatch((6, 8), (5, 7.5),
+                            connectionstyle="arc3,rad=.2",
+                            arrowstyle='-|>',
+                            mutation_scale=20,
+                            linewidth=2,
+                            color='orange')
+    ax.add_patch(arrow2)
+    
+    # App to Data
+    arrow3 = FancyArrowPatch((8, 6.5), (9, 6.5),
+                            connectionstyle="arc3,rad=0",
+                            arrowstyle='<->',
+                            mutation_scale=20,
+                            linewidth=2,
+                            color='red')
+    ax.add_patch(arrow3)
+    
+    # App to Mesh
+    arrow4 = FancyArrowPatch((4.5, 5), (4.5, 4.5),
+                            connectionstyle="arc3,rad=0",
+                            arrowstyle='<->',
+                            mutation_scale=20,
+                            linewidth=2,
+                            color='purple')
+    ax.add_patch(arrow4)
+    
+    # Mesh to Monitoring
+    arrow5 = FancyArrowPatch((8, 4), (9, 3.5),
+                            connectionstyle="arc3,rad=.3",
+                            arrowstyle='-|>',
+                            mutation_scale=20,
+                            linewidth=1.5,
+                            color='purple')
+    ax.add_patch(arrow5)
+    
+    ax.set_xlim(0, 16)
+    ax.set_ylim(0, 12)
+    ax.axis('off')
+    
+    plt.title('Claude Conductor - Kubernetes Production Architecture', fontsize=20, pad=20)
+    plt.tight_layout()
+    
+    return fig
+
+def create_deployment_evolution():
+    """Create deployment evolution diagram"""
+    fig, ax = plt.subplots(1, 1, figsize=(14, 8))
+    
+    # Define stages
+    stages = [
+        (2, 4, 'Standalone\nSingle PC', '#E8F5E9', 
+         '• 5 min setup\n• 1-4 agents\n• Local files\n• 2GB RAM'),
+        (5.5, 4, 'Docker Compose\nSingle Server', '#FFF3E0',
+         '• 10 min setup\n• 1-10 agents\n• Volumes\n• 4GB RAM'),
+        (9, 4, 'Docker Swarm\nSmall Cluster', '#FFEBEE',
+         '• 30 min setup\n• 10-50 agents\n• Multi-node\n• 8GB+ RAM'),
+        (12.5, 4, 'Kubernetes\nProduction', '#F3E5F5',
+         '• 1hr+ setup\n• Unlimited\n• Auto-scale\n• 16GB+ RAM')
+    ]
+    
+    # Draw stages
+    for i, (x, y, title, color, details) in enumerate(stages):
+        # Stage box
+        stage_box = FancyBboxPatch((x-1.2, y-1.5), 2.4, 3,
+                                  boxstyle="round,pad=0.1",
+                                  facecolor=color,
+                                  edgecolor='black',
+                                  linewidth=2)
+        ax.add_patch(stage_box)
+        
+        # Title
+        ax.text(x, y+1.2, title, ha='center', fontweight='bold', fontsize=11)
+        
+        # Details
+        ax.text(x, y-0.3, details, ha='center', fontsize=8, 
+                verticalalignment='center')
+        
+        # Complexity indicator
+        complexity = '⭐' * (i + 1)
+        ax.text(x, y-1.2, complexity, ha='center', fontsize=10)
+    
+    # Evolution arrows
+    arrow_y = 4
+    for i in range(3):
+        x1 = stages[i][0] + 1.2
+        x2 = stages[i+1][0] - 1.2
+        arrow = FancyArrowPatch((x1, arrow_y), (x2, arrow_y),
+                               connectionstyle="arc3,rad=0",
+                               arrowstyle='-|>',
+                               mutation_scale=25,
+                               linewidth=3,
+                               color='darkgreen')
+        ax.add_patch(arrow)
+        
+        # Label
+        mid_x = (x1 + x2) / 2
+        ax.text(mid_x, arrow_y + 0.3, 'Scale Up', ha='center', fontsize=8)
+    
+    # Direct path arrow
+    direct_arrow = FancyArrowPatch((2, 2), (12.5, 2),
+                                  connectionstyle="arc3,rad=-.3",
+                                  arrowstyle='-|>',
+                                  mutation_scale=25,
+                                  linewidth=2,
+                                  linestyle='dashed',
+                                  color='blue')
+    ax.add_patch(direct_arrow)
+    ax.text(7.25, 1.5, 'Direct Path (for large deployments)', 
+            ha='center', fontsize=9, color='blue')
+    
+    # Title and labels
+    ax.text(7.25, 6.5, 'Claude Conductor Deployment Evolution', 
+            ha='center', fontsize=16, fontweight='bold')
+    ax.text(7.25, 6, 'Choose based on scale, complexity, and requirements', 
+            ha='center', fontsize=10, style='italic')
+    
+    ax.set_xlim(0, 14.5)
+    ax.set_ylim(0, 7)
+    ax.axis('off')
+    
+    plt.tight_layout()
+    return fig
+
+def save_all_diagrams():
+    """Generate and save all architecture diagrams"""
+    # Create diagrams
+    standalone_fig = create_standalone_architecture()
+    k8s_fig = create_kubernetes_architecture()
+    evolution_fig = create_deployment_evolution()
+    
+    # Save as PNG
+    standalone_fig.savefig('architecture-standalone.png', dpi=300, bbox_inches='tight')
+    k8s_fig.savefig('architecture-kubernetes.png', dpi=300, bbox_inches='tight')
+    evolution_fig.savefig('architecture-evolution.png', dpi=300, bbox_inches='tight')
+    
+    # Save as SVG for scalability
+    standalone_fig.savefig('architecture-standalone.svg', format='svg', bbox_inches='tight')
+    k8s_fig.savefig('architecture-kubernetes.svg', format='svg', bbox_inches='tight')
+    evolution_fig.savefig('architecture-evolution.svg', format='svg', bbox_inches='tight')
+    
+    print("Architecture diagrams saved successfully!")
+    print("Files created:")
+    print("  - architecture-standalone.png/svg")
+    print("  - architecture-kubernetes.png/svg")
+    print("  - architecture-evolution.png/svg")
+
+if __name__ == "__main__":
+    save_all_diagrams()
+    
+    # Optionally display the diagrams
+    # plt.show()

--- a/docs/architecture-standalone.md
+++ b/docs/architecture-standalone.md
@@ -202,46 +202,46 @@ graph TB
         ArgoCD[ArgoCD<br/>GitOps]
     end
     
-    Users -->|HTTPS| CloudProvider
-    CloudProvider -->|Load Balancer| Ingress
+    Users -->["HTTPS"] CloudProvider
+    CloudProvider -->["Load Balancer"] Ingress
     Ingress --> TLS
     TLS --> DashboardPod
     TLS --> APIPod
     
-    GitHub -->|Webhook| GitHubActions
-    GitHubActions -->|Build & Push| DockerHub
-    GitHubActions -->|Deploy| ArgoCD
-    ArgoCD -->|Sync| OrchestratorPod
-    ArgoCD -->|Sync| AgentRS
+    GitHub -->["Webhook"] GitHubActions
+    GitHubActions -->["Build & Push"] DockerHub
+    GitHubActions -->["Deploy"] ArgoCD
+    ArgoCD -->["Sync"] OrchestratorPod
+    ArgoCD -->["Sync"] AgentRS
     
-    OrchestratorPod <-->|gRPC| ServiceMesh
-    DashboardPod <-->|HTTP| ServiceMesh
-    APIPod <-->|REST| ServiceMesh
-    AgentRS <-->|gRPC| ServiceMesh
+    OrchestratorPod <-->["gRPC"] ServiceMesh
+    DashboardPod <-->["HTTP"] ServiceMesh
+    APIPod <-->["REST"] ServiceMesh
+    AgentRS <-->["gRPC"] ServiceMesh
     
     ServiceMesh --> mTLS
     
-    OrchestratorPod -->|Read/Write| Redis
-    OrchestratorPod -->|Read/Write| PostgreSQL
-    AgentRS -->|Read/Write| S3
+    OrchestratorPod -->["Read/Write"] Redis
+    OrchestratorPod -->["Read/Write"] PostgreSQL
+    AgentRS -->["Read/Write"] S3
     
     OrchestratorPod --> PVC1
     AgentRS --> PVC1
     OrchestratorPod --> PVC2
     OrchestratorPod --> PVC3
     
-    HPA -->|Scale| AgentRS
-    HPA <--|Metrics| Prometheus
+    HPA -->["Scale"] AgentRS
+    HPA <--["Metrics"] Prometheus
     
-    OrchestratorPod -->|Metrics| Prometheus
-    AgentRS -->|Metrics| Prometheus
+    OrchestratorPod -->["Metrics"] Prometheus
+    AgentRS -->["Metrics"] Prometheus
     Prometheus --> Grafana
     
-    OrchestratorPod -->|Logs| Loki
-    AgentRS -->|Logs| Loki
+    OrchestratorPod -->["Logs"] Loki
+    AgentRS -->["Logs"] Loki
     Loki --> Grafana
     
-    ServiceMesh -->|Traces| Jaeger
+    ServiceMesh -->["Traces"] Jaeger
     
     style Users fill:#e1f5fe
     style Ingress fill:#ffccbc

--- a/docs/architecture-standalone.md
+++ b/docs/architecture-standalone.md
@@ -202,46 +202,46 @@ graph TB
         ArgoCD[ArgoCD<br/>GitOps]
     end
     
-    Users -->["HTTPS"] CloudProvider
-    CloudProvider -->["Load Balancer"] Ingress
+    Users --> CloudProvider
+    CloudProvider --> Ingress
     Ingress --> TLS
     TLS --> DashboardPod
     TLS --> APIPod
     
-    GitHub -->["Webhook"] GitHubActions
-    GitHubActions -->["Build & Push"] DockerHub
-    GitHubActions -->["Deploy"] ArgoCD
-    ArgoCD -->["Sync"] OrchestratorPod
-    ArgoCD -->["Sync"] AgentRS
+    GitHub --> GitHubActions
+    GitHubActions --> DockerHub
+    GitHubActions --> ArgoCD
+    ArgoCD --> OrchestratorPod
+    ArgoCD --> AgentRS
     
-    OrchestratorPod <-->["gRPC"] ServiceMesh
-    DashboardPod <-->["HTTP"] ServiceMesh
-    APIPod <-->["REST"] ServiceMesh
-    AgentRS <-->["gRPC"] ServiceMesh
+    OrchestratorPod <--> ServiceMesh
+    DashboardPod <--> ServiceMesh
+    APIPod <--> ServiceMesh
+    AgentRS <--> ServiceMesh
     
     ServiceMesh --> mTLS
     
-    OrchestratorPod -->["Read/Write"] Redis
-    OrchestratorPod -->["Read/Write"] PostgreSQL
-    AgentRS -->["Read/Write"] S3
+    OrchestratorPod --> Redis
+    OrchestratorPod --> PostgreSQL
+    AgentRS --> S3
     
     OrchestratorPod --> PVC1
     AgentRS --> PVC1
     OrchestratorPod --> PVC2
     OrchestratorPod --> PVC3
     
-    HPA -->["Scale"] AgentRS
-    HPA <--["Metrics"] Prometheus
+    HPA --> AgentRS
+    HPA <-- Prometheus
     
-    OrchestratorPod -->["Metrics"] Prometheus
-    AgentRS -->["Metrics"] Prometheus
+    OrchestratorPod --> Prometheus
+    AgentRS --> Prometheus
     Prometheus --> Grafana
     
-    OrchestratorPod -->["Logs"] Loki
-    AgentRS -->["Logs"] Loki
+    OrchestratorPod --> Loki
+    AgentRS --> Loki
     Loki --> Grafana
     
-    ServiceMesh -->["Traces"] Jaeger
+    ServiceMesh --> Jaeger
     
     style Users fill:#e1f5fe
     style Ingress fill:#ffccbc

--- a/docs/architecture-standalone.md
+++ b/docs/architecture-standalone.md
@@ -1,0 +1,326 @@
+# Claude Conductor - Architecture Diagrams
+
+## Standalone Subset Architecture (単一PC版)
+
+```mermaid
+graph TB
+    subgraph "Local Machine"
+        subgraph "User Interface"
+            Browser[Web Browser<br/>localhost:8080]
+            CLI[CLI Tool<br/>conductor]
+        end
+        
+        subgraph "Claude Conductor Core"
+            Orchestrator[Orchestrator<br/>タスク管理・分配]
+            Dashboard[Web Dashboard<br/>FastAPI/HTTP Server]
+            API[API Server<br/>REST API]
+        end
+        
+        subgraph "Agent Pool (1-4 agents)"
+            Agent1[Agent 1<br/>Claude Code Mock]
+            Agent2[Agent 2<br/>Claude Code Mock]
+            AgentN[Agent N<br/>Optional]
+        end
+        
+        subgraph "Local Storage"
+            Config[(Config<br/>YAML)]
+            Workspace[(Workspace<br/>Files)]
+            Logs[(Logs<br/>Text Files)]
+        end
+        
+        subgraph "Communication"
+            Queue[In-Memory Queue<br/>タスクキュー]
+            Socket[Unix Socket<br/>エージェント通信]
+        end
+    end
+    
+    Browser -->|HTTP/WebSocket| Dashboard
+    CLI -->|Python API| Orchestrator
+    Dashboard -->|Internal API| Orchestrator
+    API -->|REST| Orchestrator
+    
+    Orchestrator -->|Task Assignment| Queue
+    Queue -->|Task Distribution| Agent1
+    Queue -->|Task Distribution| Agent2
+    Queue -.->|Optional| AgentN
+    
+    Agent1 <-->|Unix Socket| Socket
+    Agent2 <-->|Unix Socket| Socket
+    AgentN <-.->|Unix Socket| Socket
+    
+    Orchestrator -->|Read/Write| Config
+    Agent1 -->|Read/Write| Workspace
+    Agent2 -->|Read/Write| Workspace
+    Orchestrator -->|Write| Logs
+    
+    style Browser fill:#e1f5fe
+    style CLI fill:#e1f5fe
+    style Orchestrator fill:#fff3e0
+    style Dashboard fill:#fff3e0
+    style API fill:#fff3e0
+    style Agent1 fill:#e8f5e9
+    style Agent2 fill:#e8f5e9
+    style AgentN fill:#f3e5f5
+    style Queue fill:#fce4ec
+    style Socket fill:#fce4ec
+    style Config fill:#f5f5f5
+    style Workspace fill:#f5f5f5
+    style Logs fill:#f5f5f5
+```
+
+### Standalone版の特徴:
+- **シンプルな構成**: 単一マシンで完結
+- **軽量リソース**: メモリ2GB、CPU 0.5-2コア
+- **ローカルストレージ**: ファイルベースの永続化
+- **インメモリキュー**: Redisなしでの動作
+- **Mockモード**: Claude Code CLIのモック実装
+
+---
+
+## Docker Compose Standalone Architecture
+
+```mermaid
+graph TB
+    subgraph "Docker Host"
+        subgraph "Docker Network: conductor-standalone"
+            subgraph "Main Container"
+                ConductorContainer[claude-conductor-standalone<br/>Orchestrator + Dashboard]
+                Supervisor[Supervisor<br/>プロセス管理]
+            end
+            
+            subgraph "Optional Containers"
+                Redis[(Redis<br/>Optional)]
+                FileServer[Nginx<br/>File Server<br/>:8090]
+            end
+        end
+        
+        subgraph "Docker Volumes"
+            VolumeWorkspace[(conductor_workspace<br/>~/.claude-conductor/workspace)]
+            VolumeLogs[(conductor_logs<br/>~/.claude-conductor/logs)]
+            VolumeConfig[(conductor_config<br/>~/.claude-conductor/config)]
+        end
+        
+        subgraph "Host Ports"
+            Port8080[8080: Dashboard]
+            Port8081[8081: API]
+            Port8090[8090: Files]
+        end
+    end
+    
+    subgraph "External Access"
+        UserBrowser[User Browser]
+        UserCLI[User CLI]
+    end
+    
+    UserBrowser -->|HTTP| Port8080
+    UserCLI -->|HTTP API| Port8081
+    UserBrowser -.->|HTTP| Port8090
+    
+    Port8080 --> ConductorContainer
+    Port8081 --> ConductorContainer
+    Port8090 -.-> FileServer
+    
+    ConductorContainer --> Supervisor
+    ConductorContainer -.->|Optional| Redis
+    
+    ConductorContainer --> VolumeWorkspace
+    ConductorContainer --> VolumeLogs
+    ConductorContainer --> VolumeConfig
+    FileServer -.-> VolumeWorkspace
+    FileServer -.-> VolumeLogs
+    
+    style UserBrowser fill:#e1f5fe
+    style UserCLI fill:#e1f5fe
+    style ConductorContainer fill:#fff3e0
+    style Supervisor fill:#fff3e0
+    style Redis fill:#ffebee
+    style FileServer fill:#ffebee
+    style VolumeWorkspace fill:#f5f5f5
+    style VolumeLogs fill:#f5f5f5
+    style VolumeConfig fill:#f5f5f5
+```
+
+---
+
+## Full Production Architecture (フルセット版)
+
+```mermaid
+graph TB
+    subgraph "External Services"
+        Users[Users/Developers]
+        GitHub[GitHub<br/>Code Repository]
+        DockerHub[Docker Hub<br/>Container Registry]
+        CloudProvider[Cloud Provider<br/>AWS/GCP/Azure]
+    end
+    
+    subgraph "Kubernetes Cluster"
+        subgraph "Ingress Layer"
+            Ingress[NGINX Ingress<br/>Load Balancer]
+            TLS[TLS Termination<br/>HTTPS]
+        end
+        
+        subgraph "Application Layer"
+            subgraph "Orchestrator Pod"
+                OrchestratorPod[Orchestrator<br/>StatefulSet]
+                DashboardPod[Dashboard<br/>Deployment]
+                APIPod[API Server<br/>Deployment]
+            end
+            
+            subgraph "Agent Pool"
+                AgentRS[Agent ReplicaSet<br/>3-10 replicas]
+                HPA[Horizontal Pod<br/>Autoscaler]
+            end
+        end
+        
+        subgraph "Data Layer"
+            Redis[(Redis Cluster<br/>Task Queue)]
+            PostgreSQL[(PostgreSQL<br/>Metadata)]
+            S3[(S3/MinIO<br/>Object Storage)]
+        end
+        
+        subgraph "Service Mesh"
+            ServiceMesh[Istio/Linkerd<br/>Service Mesh]
+            mTLS[mTLS<br/>Inter-service]
+        end
+        
+        subgraph "Monitoring Stack"
+            Prometheus[Prometheus<br/>Metrics]
+            Grafana[Grafana<br/>Visualization]
+            Loki[Loki<br/>Log Aggregation]
+            Jaeger[Jaeger<br/>Tracing]
+        end
+        
+        subgraph "Storage"
+            PVC1[(PVC: Workspace<br/>ReadWriteMany)]
+            PVC2[(PVC: Logs<br/>ReadWriteMany)]
+            PVC3[(PVC: Config<br/>ReadWriteOnce)]
+        end
+    end
+    
+    subgraph "CI/CD Pipeline"
+        GitHubActions[GitHub Actions<br/>CI/CD]
+        ArgoCD[ArgoCD<br/>GitOps]
+    end
+    
+    Users -->|HTTPS| CloudProvider
+    CloudProvider -->|Load Balancer| Ingress
+    Ingress --> TLS
+    TLS --> DashboardPod
+    TLS --> APIPod
+    
+    GitHub -->|Webhook| GitHubActions
+    GitHubActions -->|Build & Push| DockerHub
+    GitHubActions -->|Deploy| ArgoCD
+    ArgoCD -->|Sync| OrchestratorPod
+    ArgoCD -->|Sync| AgentRS
+    
+    OrchestratorPod <-->|gRPC| ServiceMesh
+    DashboardPod <-->|HTTP| ServiceMesh
+    APIPod <-->|REST| ServiceMesh
+    AgentRS <-->|gRPC| ServiceMesh
+    
+    ServiceMesh --> mTLS
+    
+    OrchestratorPod -->|Read/Write| Redis
+    OrchestratorPod -->|Read/Write| PostgreSQL
+    AgentRS -->|Read/Write| S3
+    
+    OrchestratorPod --> PVC1
+    AgentRS --> PVC1
+    OrchestratorPod --> PVC2
+    OrchestratorPod --> PVC3
+    
+    HPA -->|Scale| AgentRS
+    HPA <--|Metrics| Prometheus
+    
+    OrchestratorPod -->|Metrics| Prometheus
+    AgentRS -->|Metrics| Prometheus
+    Prometheus --> Grafana
+    
+    OrchestratorPod -->|Logs| Loki
+    AgentRS -->|Logs| Loki
+    Loki --> Grafana
+    
+    ServiceMesh -->|Traces| Jaeger
+    
+    style Users fill:#e1f5fe
+    style Ingress fill:#ffccbc
+    style TLS fill:#ffccbc
+    style OrchestratorPod fill:#fff3e0
+    style DashboardPod fill:#fff3e0
+    style APIPod fill:#fff3e0
+    style AgentRS fill:#e8f5e9
+    style HPA fill:#e8f5e9
+    style Redis fill:#ffebee
+    style PostgreSQL fill:#ffebee
+    style S3 fill:#ffebee
+    style Prometheus fill:#f3e5f5
+    style Grafana fill:#f3e5f5
+    style ServiceMesh fill:#fce4ec
+```
+
+### フルセット版の特徴:
+- **高可用性**: マルチレプリカ、自動フェイルオーバー
+- **自動スケーリング**: HPA、VPA、Cluster Autoscaler
+- **エンタープライズセキュリティ**: mTLS、RBAC、Network Policies
+- **完全な監視**: メトリクス、ログ、トレーシング
+- **GitOps**: 宣言的デプロイメント、自動同期
+
+---
+
+## Component Communication Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Dashboard
+    participant Orchestrator
+    participant Queue
+    participant Agent
+    participant Storage
+    
+    User->>Dashboard: Submit Task
+    Dashboard->>Orchestrator: Create Task Request
+    Orchestrator->>Queue: Enqueue Task
+    Orchestrator->>Storage: Save Task Metadata
+    
+    Agent->>Queue: Poll for Tasks
+    Queue-->>Agent: Return Task
+    Agent->>Agent: Execute Task
+    Agent->>Storage: Write Results
+    Agent->>Orchestrator: Report Completion
+    
+    Orchestrator->>Storage: Update Task Status
+    Orchestrator->>Dashboard: Send Update (WebSocket)
+    Dashboard-->>User: Display Results
+    
+    Note over Agent: Health Check Loop
+    loop Every 30s
+        Agent->>Orchestrator: Health Check Ping
+        Orchestrator-->>Agent: Acknowledge
+    end
+```
+
+---
+
+## Deployment Evolution Path
+
+```mermaid
+graph LR
+    A[Standalone<br/>Single PC] -->|Scale Up| B[Docker Compose<br/>Single Server]
+    B -->|Scale Out| C[Docker Swarm<br/>Small Cluster]
+    C -->|Enterprise| D[Kubernetes<br/>Production]
+    
+    A -->|Direct Path| D
+    
+    style A fill:#e8f5e9
+    style B fill:#fff3e0
+    style C fill:#ffebee
+    style D fill:#f3e5f5
+```
+
+### 移行パス:
+1. **Standalone → Docker Compose**: コンテナ化による安定性向上
+2. **Docker Compose → Swarm**: 複数ノードへの展開
+3. **Swarm → Kubernetes**: エンタープライズ機能の活用
+4. **Direct to K8s**: 大規模展開の場合は直接移行

--- a/examples/standalone_examples.py
+++ b/examples/standalone_examples.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+Claude Conductor - Standalone Examples
+シンプルな使用例とサンプルタスク
+"""
+
+import time
+import os
+from conductor import create_task, Orchestrator
+from conductor.utils import setup_logger
+
+# ログ設定
+logger = setup_logger("standalone_examples", level="INFO")
+
+def example_basic_tasks():
+    """基本的なタスクの例"""
+    print("🚀 基本的なタスクの例")
+    print("=" * 50)
+    
+    # 1. シンプルなコマンド実行
+    task1 = create_task(
+        task_type="generic",
+        description="echo 'Hello from Claude Conductor!'",
+        priority=5
+    )
+    print(f"✅ Task 1 created: {task1.task_id}")
+    print(f"   Type: {task1.task_type}")
+    print(f"   Description: {task1.description}")
+    
+    # 2. ファイル操作
+    task2 = create_task(
+        task_type="generic", 
+        description="ls -la && pwd",
+        priority=4
+    )
+    print(f"✅ Task 2 created: {task2.task_id}")
+    
+    # 3. Python コード実行
+    task3 = create_task(
+        task_type="generic",
+        description="python3 -c \"import sys; print(f'Python version: {sys.version}')\"",
+        priority=6
+    )
+    print(f"✅ Task 3 created: {task3.task_id}")
+    
+    return [task1, task2, task3]
+
+def example_code_review():
+    """コードレビュータスクの例"""
+    print("\n📝 コードレビュータスクの例")
+    print("=" * 50)
+    
+    # サンプルPythonファイルを作成
+    sample_code = '''
+def calculate_fibonacci(n):
+    """フィボナッチ数列の計算"""
+    if n <= 1:
+        return n
+    return calculate_fibonacci(n-1) + calculate_fibonacci(n-2)
+
+def main():
+    print("フィボナッチ数列:")
+    for i in range(10):
+        print(f"F({i}) = {calculate_fibonacci(i)}")
+
+if __name__ == "__main__":
+    main()
+'''
+    
+    # ワークスペースディレクトリを作成
+    workspace_dir = os.path.expanduser("~/.claude-conductor/workspace")
+    os.makedirs(workspace_dir, exist_ok=True)
+    
+    # サンプルファイルを保存
+    sample_file = os.path.join(workspace_dir, "fibonacci.py")
+    with open(sample_file, 'w') as f:
+        f.write(sample_code)
+    
+    print(f"📄 Sample file created: {sample_file}")
+    
+    # コードレビュータスクを作成
+    review_task = create_task(
+        task_type="code_review",
+        description="Review Python code for optimization and best practices",
+        files=["fibonacci.py"],
+        priority=8
+    )
+    
+    print(f"✅ Code review task created: {review_task.task_id}")
+    print(f"   Files to review: {review_task.files}")
+    
+    return review_task
+
+def example_parallel_tasks():
+    """並列タスクの例"""
+    print("\n⚡ 並列タスクの例")
+    print("=" * 50)
+    
+    # 複数のサブタスクを含む並列タスク
+    parallel_task = create_task(
+        task_type="analysis",
+        description="Parallel analysis of multiple components",
+        parallel=True,
+        subtasks=[
+            {
+                "type": "generic",
+                "description": "echo 'Analyzing component 1...' && sleep 2"
+            },
+            {
+                "type": "generic", 
+                "description": "echo 'Analyzing component 2...' && sleep 2"
+            },
+            {
+                "type": "generic",
+                "description": "echo 'Analyzing component 3...' && sleep 2"
+            }
+        ],
+        priority=7
+    )
+    
+    print(f"✅ Parallel task created: {parallel_task.task_id}")
+    print(f"   Subtasks count: {len(parallel_task.subtasks)}")
+    print(f"   Parallel execution: {parallel_task.parallel}")
+    
+    return parallel_task
+
+def example_priority_tasks():
+    """優先度付きタスクの例"""
+    print("\n🎯 優先度付きタスクの例")
+    print("=" * 50)
+    
+    tasks = []
+    priorities = [1, 5, 10]  # 低、中、高
+    priority_names = ["Low", "Medium", "High"]
+    
+    for priority, name in zip(priorities, priority_names):
+        task = create_task(
+            task_type="generic",
+            description=f"echo 'This is a {name.lower()} priority task'",
+            priority=priority
+        )
+        tasks.append(task)
+        print(f"✅ {name} priority task created: {task.task_id} (Priority: {priority})")
+    
+    return tasks
+
+def example_configuration_test():
+    """設定テストの例"""
+    print("\n⚙️ 設定テストの例")
+    print("=" * 50)
+    
+    # 設定ファイルの場所を確認
+    config_dir = os.path.expanduser("~/.claude-conductor/config")
+    config_file = os.path.join(config_dir, "config.yaml")
+    
+    if os.path.exists(config_file):
+        print(f"✅ Configuration file found: {config_file}")
+        
+        # 設定内容を表示するタスク
+        config_task = create_task(
+            task_type="generic",
+            description=f"cat {config_file}",
+            priority=3
+        )
+        print(f"✅ Config display task created: {config_task.task_id}")
+        return config_task
+    else:
+        print(f"❌ Configuration file not found: {config_file}")
+        print("   Run './quick-start.sh' first to set up the environment")
+        return None
+
+def example_workspace_setup():
+    """ワークスペースセットアップの例"""
+    print("\n📁 ワークスペースセットアップの例")
+    print("=" * 50)
+    
+    workspace_dir = os.path.expanduser("~/.claude-conductor/workspace")
+    
+    # ディレクトリ構造を作成
+    directories = [
+        "projects/sample-project",
+        "scripts",
+        "data",
+        "outputs"
+    ]
+    
+    for directory in directories:
+        full_path = os.path.join(workspace_dir, directory)
+        os.makedirs(full_path, exist_ok=True)
+        print(f"📁 Created directory: {directory}")
+    
+    # サンプルファイルを作成
+    files = {
+        "scripts/hello.py": "print('Hello from Claude Conductor!')",
+        "scripts/system_info.py": """
+import platform
+import sys
+
+print(f"OS: {platform.system()} {platform.release()}")
+print(f"Python: {sys.version}")
+print(f"Platform: {platform.platform()}")
+""",
+        "projects/sample-project/README.md": """
+# Sample Project
+
+This is a sample project for Claude Conductor demonstration.
+
+## Features
+- Task execution
+- File processing
+- Code analysis
+""",
+        "data/sample.txt": "This is sample data for processing."
+    }
+    
+    for file_path, content in files.items():
+        full_path = os.path.join(workspace_dir, file_path)
+        with open(full_path, 'w') as f:
+            f.write(content.strip())
+        print(f"📄 Created file: {file_path}")
+    
+    # ワークスペース確認タスク
+    workspace_task = create_task(
+        task_type="generic",
+        description=f"find {workspace_dir} -type f -name '*.py' -o -name '*.md' -o -name '*.txt' | head -20",
+        priority=4
+    )
+    
+    print(f"✅ Workspace exploration task created: {workspace_task.task_id}")
+    return workspace_task
+
+def run_orchestrator_example():
+    """オーケストレーター実行例（デモ用）"""
+    print("\n🎭 オーケストレーター実行例（デモ）")
+    print("=" * 50)
+    print("注意: この例は実際にオーケストレーターを起動しません")
+    print("実際の実行には 'conductor start' を使用してください")
+    
+    # デモ用のオーケストレーター設定
+    print("\n設定例:")
+    demo_config = {
+        "num_agents": 2,
+        "max_workers": 4,
+        "task_timeout": 120,
+        "log_level": "INFO"
+    }
+    
+    for key, value in demo_config.items():
+        print(f"  {key}: {value}")
+    
+    # サンプルタスクの実行シミュレーション
+    print("\nタスク実行シミュレーション:")
+    sample_task = create_task(
+        task_type="generic",
+        description="echo 'Simulated task execution'",
+        priority=5
+    )
+    
+    print(f"1. Task created: {sample_task.task_id}")
+    print("2. Task queued for execution")
+    print("3. Agent assignment: agent_001")
+    print("4. Task execution started")
+    print("5. Task execution completed")
+    print("6. Results stored")
+    
+    return sample_task
+
+def main():
+    """メイン実行関数"""
+    print("🎭 Claude Conductor - Standalone Examples")
+    print("=" * 60)
+    print("これらの例は、Claude Conductorの基本的な使用方法を示しています")
+    print("実際の実行には、先に 'conductor start' でシステムを起動してください")
+    print("=" * 60)
+    
+    try:
+        # 各例を実行
+        basic_tasks = example_basic_tasks()
+        review_task = example_code_review()
+        parallel_task = example_parallel_tasks()
+        priority_tasks = example_priority_tasks()
+        config_task = example_configuration_test()
+        workspace_task = example_workspace_setup()
+        orchestrator_demo = run_orchestrator_example()
+        
+        # 実行サマリー
+        print("\n📊 実行サマリー")
+        print("=" * 50)
+        
+        all_tasks = []
+        if basic_tasks:
+            all_tasks.extend(basic_tasks)
+        if review_task:
+            all_tasks.append(review_task)
+        if parallel_task:
+            all_tasks.append(parallel_task)
+        if priority_tasks:
+            all_tasks.extend(priority_tasks)
+        if config_task:
+            all_tasks.append(config_task)
+        if workspace_task:
+            all_tasks.append(workspace_task)
+        if orchestrator_demo:
+            all_tasks.append(orchestrator_demo)
+        
+        print(f"✅ Total tasks created: {len(all_tasks)}")
+        
+        # タスクタイプ別集計
+        task_types = {}
+        for task in all_tasks:
+            task_type = task.task_type
+            task_types[task_type] = task_types.get(task_type, 0) + 1
+        
+        print("\nタスクタイプ別:")
+        for task_type, count in task_types.items():
+            print(f"  {task_type}: {count}")
+        
+        print("\n🚀 次のステップ:")
+        print("1. 'conductor start' でシステムを起動")
+        print("2. http://localhost:8080 でダッシュボードにアクセス")
+        print("3. 上記で作成されたファイルを使ってタスクを実行")
+        print("4. 'conductor test' で基本動作を確認")
+        
+    except Exception as e:
+        logger.error(f"Example execution failed: {e}")
+        print(f"❌ エラーが発生しました: {e}")
+        return 1
+    
+    return 0
+
+if __name__ == "__main__":
+    exit(main())

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -1,0 +1,500 @@
+#!/bin/bash
+set -e
+
+# Claude Conductor - Quick Start Script for Single PC
+# This script sets up a minimal, standalone version of Claude Conductor
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONDUCTOR_HOME="$HOME/.claude-conductor"
+VENV_DIR="$CONDUCTOR_HOME/venv"
+CONFIG_DIR="$CONDUCTOR_HOME/config"
+WORKSPACE_DIR="$CONDUCTOR_HOME/workspace"
+LOGS_DIR="$CONDUCTOR_HOME/logs"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check system requirements
+check_requirements() {
+    log_info "Checking system requirements..."
+    
+    # Check Python
+    if ! command -v python3 &> /dev/null; then
+        log_error "Python 3 is required but not installed"
+        exit 1
+    fi
+    
+    local python_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+    log_info "Found Python $python_version"
+    
+    if [[ $(echo "$python_version >= 3.10" | bc -l) -eq 0 ]]; then
+        log_warning "Python 3.10+ is recommended, but $python_version should work"
+    fi
+    
+    # Check pip
+    if ! command -v pip3 &> /dev/null && ! python3 -m pip --version &> /dev/null; then
+        log_error "pip is required but not installed"
+        exit 1
+    fi
+    
+    # Check for container runtime (optional)
+    if command -v docker &> /dev/null; then
+        log_info "Docker detected - container mode available"
+        CONTAINER_RUNTIME="docker"
+    elif command -v podman &> /dev/null; then
+        log_info "Podman detected - container mode available"
+        CONTAINER_RUNTIME="podman"
+    else
+        log_warning "No container runtime detected - running in local mode only"
+        CONTAINER_RUNTIME=""
+    fi
+    
+    log_success "System requirements check completed"
+}
+
+# Create directory structure
+setup_directories() {
+    log_info "Setting up directory structure..."
+    
+    mkdir -p "$CONDUCTOR_HOME"
+    mkdir -p "$CONFIG_DIR"
+    mkdir -p "$WORKSPACE_DIR"
+    mkdir -p "$LOGS_DIR"
+    
+    log_success "Directory structure created at $CONDUCTOR_HOME"
+}
+
+# Setup Python virtual environment
+setup_python_env() {
+    log_info "Setting up Python virtual environment..."
+    
+    # Create virtual environment
+    python3 -m venv "$VENV_DIR"
+    
+    # Activate virtual environment
+    source "$VENV_DIR/bin/activate"
+    
+    # Upgrade pip
+    pip install --upgrade pip
+    
+    # Install Claude Conductor in development mode
+    pip install -e "$SCRIPT_DIR"
+    
+    log_success "Python environment setup completed"
+}
+
+# Create minimal configuration
+create_config() {
+    log_info "Creating minimal configuration..."
+    
+    cat > "$CONFIG_DIR/config.yaml" << EOF
+# Claude Conductor - Standalone Configuration
+num_agents: 2
+max_workers: 4
+task_timeout: 120
+log_level: "INFO"
+
+# Simplified container configuration
+container_config:
+  image: "ubuntu:22.04"
+  memory_limit: "1g"
+  cpu_limit: "0.5"
+
+# Local storage paths
+storage:
+  workspace_path: "$WORKSPACE_DIR"
+  logs_path: "$LOGS_DIR"
+
+# Network configuration
+network:
+  dashboard_port: 8080
+  health_check_interval: 30
+
+# Disable complex features for standalone mode
+features:
+  redis_enabled: false
+  monitoring_enabled: false
+  clustering_enabled: false
+EOF
+
+    log_success "Configuration created at $CONFIG_DIR/config.yaml"
+}
+
+# Create simple docker-compose for standalone mode
+create_simple_compose() {
+    if [ -z "$CONTAINER_RUNTIME" ]; then
+        log_info "Skipping Docker Compose creation (no container runtime)"
+        return
+    fi
+    
+    log_info "Creating simplified Docker Compose configuration..."
+    
+    cat > "$CONDUCTOR_HOME/docker-compose.yml" << EOF
+version: '3.8'
+
+services:
+  conductor-standalone:
+    build:
+      context: $SCRIPT_DIR
+      dockerfile: containers/Dockerfile
+      target: production
+    container_name: claude-conductor-standalone
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - conductor_workspace:/workspace
+      - conductor_logs:/var/log/conductor
+    environment:
+      - CONDUCTOR_MODE=standalone
+      - CONDUCTOR_LOG_LEVEL=INFO
+      - CONDUCTOR_NUM_AGENTS=2
+    command: ["full"]
+    healthcheck:
+      test: ["CMD", "/healthcheck.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  conductor_workspace:
+  conductor_logs:
+EOF
+
+    log_success "Docker Compose configuration created"
+}
+
+# Create startup scripts
+create_scripts() {
+    log_info "Creating startup scripts..."
+    
+    # Local startup script
+    cat > "$CONDUCTOR_HOME/start-local.sh" << EOF
+#!/bin/bash
+# Start Claude Conductor in local mode
+
+cd "$CONDUCTOR_HOME"
+source "$VENV_DIR/bin/activate"
+
+echo "Starting Claude Conductor locally..."
+echo "Dashboard will be available at: http://localhost:8080"
+echo "Press Ctrl+C to stop"
+
+python -m conductor.orchestrator --config "$CONFIG_DIR/config.yaml" &
+ORCHESTRATOR_PID=\$!
+
+python "$SCRIPT_DIR/web/dashboard.py" --port 8080 --no-browser &
+DASHBOARD_PID=\$!
+
+# Wait for processes
+wait \$ORCHESTRATOR_PID \$DASHBOARD_PID
+EOF
+
+    # Container startup script
+    if [ -n "$CONTAINER_RUNTIME" ]; then
+        cat > "$CONDUCTOR_HOME/start-container.sh" << EOF
+#!/bin/bash
+# Start Claude Conductor in container mode
+
+cd "$CONDUCTOR_HOME"
+
+echo "Starting Claude Conductor in container..."
+echo "Dashboard will be available at: http://localhost:8080"
+echo "Press Ctrl+C to stop"
+
+$CONTAINER_RUNTIME compose up --build
+EOF
+    fi
+    
+    # Stop script
+    cat > "$CONDUCTOR_HOME/stop.sh" << EOF
+#!/bin/bash
+# Stop Claude Conductor
+
+echo "Stopping Claude Conductor..."
+
+# Stop local processes
+pkill -f "conductor.orchestrator" || true
+pkill -f "dashboard.py" || true
+
+# Stop containers if running
+if [ -n "$CONTAINER_RUNTIME" ]; then
+    cd "$CONDUCTOR_HOME"
+    $CONTAINER_RUNTIME compose down || true
+fi
+
+echo "Claude Conductor stopped"
+EOF
+    
+    # Make scripts executable
+    chmod +x "$CONDUCTOR_HOME"/*.sh
+    
+    log_success "Startup scripts created"
+}
+
+# Create CLI wrapper
+create_cli_wrapper() {
+    log_info "Creating CLI wrapper..."
+    
+    cat > "$CONDUCTOR_HOME/conductor" << EOF
+#!/bin/bash
+# Claude Conductor CLI wrapper
+
+CONDUCTOR_HOME="$CONDUCTOR_HOME"
+VENV_DIR="$VENV_DIR"
+CONFIG_DIR="$CONFIG_DIR"
+
+# Activate Python environment
+source "\$VENV_DIR/bin/activate"
+
+case "\$1" in
+    "start")
+        echo "Starting Claude Conductor..."
+        "\$CONDUCTOR_HOME/start-local.sh"
+        ;;
+    "start-container")
+        echo "Starting Claude Conductor in container mode..."
+        "\$CONDUCTOR_HOME/start-container.sh"
+        ;;
+    "stop")
+        "\$CONDUCTOR_HOME/stop.sh"
+        ;;
+    "status")
+        echo "Checking Claude Conductor status..."
+        if pgrep -f "conductor.orchestrator" > /dev/null; then
+            echo "Orchestrator: Running"
+        else
+            echo "Orchestrator: Stopped"
+        fi
+        if pgrep -f "dashboard.py" > /dev/null; then
+            echo "Dashboard: Running"
+        else
+            echo "Dashboard: Stopped"
+        fi
+        ;;
+    "logs")
+        echo "Recent logs:"
+        tail -n 50 "\$CONDUCTOR_HOME/logs"/*.log 2>/dev/null || echo "No logs found"
+        ;;
+    "config")
+        echo "Opening configuration file..."
+        \${EDITOR:-nano} "\$CONFIG_DIR/config.yaml"
+        ;;
+    "dashboard")
+        echo "Opening dashboard..."
+        python -c "import webbrowser; webbrowser.open('http://localhost:8080')"
+        ;;
+    "test")
+        echo "Running basic test..."
+        python -c "
+from conductor import create_task, Orchestrator
+print('Creating test task...')
+task = create_task(task_type='generic', description='echo \"Hello from Claude Conductor!\"')
+print(f'Task created: {task.task_id}')
+print('Test completed successfully!')
+"
+        ;;
+    *)
+        echo "Claude Conductor - Standalone Mode"
+        echo ""
+        echo "Usage: \$0 [command]"
+        echo ""
+        echo "Commands:"
+        echo "  start           Start in local mode"
+        echo "  start-container Start in container mode"
+        echo "  stop            Stop all services"
+        echo "  status          Show service status"
+        echo "  logs            Show recent logs"
+        echo "  config          Edit configuration"
+        echo "  dashboard       Open web dashboard"
+        echo "  test            Run basic test"
+        echo ""
+        echo "Dashboard: http://localhost:8080"
+        echo "Config:    \$CONFIG_DIR/config.yaml"
+        echo "Logs:      \$CONDUCTOR_HOME/logs/"
+        ;;
+esac
+EOF
+
+    chmod +x "$CONDUCTOR_HOME/conductor"
+    
+    log_success "CLI wrapper created at $CONDUCTOR_HOME/conductor"
+}
+
+# Create quick start documentation
+create_documentation() {
+    log_info "Creating quick start documentation..."
+    
+    cat > "$CONDUCTOR_HOME/README.md" << EOF
+# Claude Conductor - Standalone Setup
+
+This is a simplified, single-PC installation of Claude Conductor.
+
+## Quick Start
+
+1. **Start the system:**
+   \`\`\`bash
+   ./conductor start
+   \`\`\`
+
+2. **Open the dashboard:**
+   - URL: http://localhost:8080
+   - Or run: \`./conductor dashboard\`
+
+3. **Submit a test task:**
+   \`\`\`bash
+   ./conductor test
+   \`\`\`
+
+4. **Stop the system:**
+   \`\`\`bash
+   ./conductor stop
+   \`\`\`
+
+## Directory Structure
+
+- **Config:** \`$CONFIG_DIR/\`
+- **Workspace:** \`$WORKSPACE_DIR/\`
+- **Logs:** \`$LOGS_DIR/\`
+- **Python Env:** \`$VENV_DIR/\`
+
+## Available Commands
+
+- \`./conductor start\` - Start local mode
+- \`./conductor start-container\` - Start container mode  
+- \`./conductor stop\` - Stop all services
+- \`./conductor status\` - Check service status
+- \`./conductor logs\` - View recent logs
+- \`./conductor config\` - Edit configuration
+- \`./conductor dashboard\` - Open web dashboard
+- \`./conductor test\` - Run basic test
+
+## Configuration
+
+Edit \`$CONFIG_DIR/config.yaml\` to customize:
+- Number of agents
+- Resource limits
+- Log levels
+- Storage paths
+
+## Troubleshooting
+
+1. **Check status:** \`./conductor status\`
+2. **View logs:** \`./conductor logs\`
+3. **Restart:** \`./conductor stop && ./conductor start\`
+
+## Advanced Usage
+
+For production deployment, see the full documentation in the main repository.
+EOF
+
+    log_success "Documentation created at $CONDUCTOR_HOME/README.md"
+}
+
+# Add to PATH
+setup_path() {
+    log_info "Setting up PATH..."
+    
+    # Add to bashrc if not already there
+    if ! grep -q "claude-conductor" ~/.bashrc 2>/dev/null; then
+        echo "" >> ~/.bashrc
+        echo "# Claude Conductor" >> ~/.bashrc
+        echo "export PATH=\"$CONDUCTOR_HOME:\$PATH\"" >> ~/.bashrc
+        echo "alias conductor=\"$CONDUCTOR_HOME/conductor\"" >> ~/.bashrc
+        
+        log_success "Added to ~/.bashrc (restart terminal or run 'source ~/.bashrc')"
+    fi
+    
+    # Create symlink for current session
+    if [ -w "/usr/local/bin" ]; then
+        ln -sf "$CONDUCTOR_HOME/conductor" "/usr/local/bin/conductor" 2>/dev/null || true
+    fi
+}
+
+# Main installation function
+main() {
+    echo "=================================="
+    echo "Claude Conductor - Quick Start"
+    echo "Single PC Standalone Installation"
+    echo "=================================="
+    echo ""
+    
+    check_requirements
+    setup_directories
+    setup_python_env
+    create_config
+    create_simple_compose
+    create_scripts
+    create_cli_wrapper
+    create_documentation
+    setup_path
+    
+    echo ""
+    echo "=================================="
+    log_success "Installation completed!"
+    echo "=================================="
+    echo ""
+    echo "🚀 Quick Start:"
+    echo "   cd $CONDUCTOR_HOME"
+    echo "   ./conductor start"
+    echo ""
+    echo "🌐 Dashboard: http://localhost:8080"
+    echo "📖 Documentation: $CONDUCTOR_HOME/README.md"
+    echo "⚙️  Configuration: $CONFIG_DIR/config.yaml"
+    echo ""
+    echo "Run './conductor' for all available commands"
+    echo ""
+}
+
+# Handle command line arguments
+case "${1:-install}" in
+    "install")
+        main
+        ;;
+    "uninstall")
+        log_info "Uninstalling Claude Conductor..."
+        "$CONDUCTOR_HOME/stop.sh" 2>/dev/null || true
+        rm -rf "$CONDUCTOR_HOME"
+        # Remove from bashrc
+        sed -i '/# Claude Conductor/,+2d' ~/.bashrc 2>/dev/null || true
+        # Remove symlink
+        rm -f "/usr/local/bin/conductor" 2>/dev/null || true
+        log_success "Uninstallation completed"
+        ;;
+    "help"|"-h"|"--help")
+        echo "Claude Conductor Quick Start"
+        echo ""
+        echo "Usage: $0 [command]"
+        echo ""
+        echo "Commands:"
+        echo "  install     Install Claude Conductor (default)"
+        echo "  uninstall   Remove Claude Conductor completely"
+        echo "  help        Show this help message"
+        ;;
+    *)
+        log_error "Unknown command: $1"
+        echo "Run '$0 help' for usage information"
+        exit 1
+        ;;
+esac

--- a/simple-setup.sh
+++ b/simple-setup.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+set -e
+
+# Claude Conductor - Simple Setup Script
+# 最小限のセットアップスクリプト（より軽量版）
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${BLUE}🎭 Claude Conductor - Simple Setup${NC}"
+echo "=================================="
+
+# 基本チェック
+if ! command -v python3 &> /dev/null; then
+    echo "❌ Python 3 is required"
+    exit 1
+fi
+
+if ! command -v git &> /dev/null; then
+    echo "❌ Git is required"
+    exit 1
+fi
+
+# 簡単セットアップ
+SETUP_DIR="$HOME/claude-conductor-simple"
+
+echo -e "${BLUE}📁 Setting up in: $SETUP_DIR${NC}"
+
+# ディレクトリ作成
+mkdir -p "$SETUP_DIR"
+cd "$SETUP_DIR"
+
+# 仮想環境作成
+echo -e "${BLUE}🐍 Creating Python environment...${NC}"
+python3 -m venv venv
+source venv/bin/activate
+
+# 依存関係インストール
+echo -e "${BLUE}📦 Installing dependencies...${NC}"
+pip install --upgrade pip
+pip install pyyaml psutil fastapi uvicorn jinja2 websockets
+
+# 簡単な設定ファイル作成
+echo -e "${BLUE}⚙️ Creating configuration...${NC}"
+cat > config.yaml << 'EOF'
+num_agents: 1
+max_workers: 2
+task_timeout: 60
+log_level: "INFO"
+
+features:
+  redis_enabled: false
+  monitoring_enabled: false
+  web_dashboard: true
+
+network:
+  dashboard_port: 8080
+EOF
+
+# 簡単なランチャースクリプト作成
+echo -e "${BLUE}🚀 Creating launcher...${NC}"
+cat > run.sh << 'EOF'
+#!/bin/bash
+cd "$(dirname "$0")"
+source venv/bin/activate
+
+echo "🎭 Starting Claude Conductor (Simple Mode)"
+echo "Dashboard: http://localhost:8080"
+echo "Press Ctrl+C to stop"
+
+# シンプルなダッシュボードサーバー
+python3 -c "
+import http.server
+import socketserver
+import webbrowser
+import threading
+import time
+
+PORT = 8080
+
+html_content = '''
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Claude Conductor - Simple</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }
+        .card { background: #f8f9fa; padding: 20px; margin: 20px 0; border-radius: 8px; border-left: 4px solid #007bff; }
+        .button { background: #007bff; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer; }
+        .status { padding: 10px; margin: 10px 0; border-radius: 5px; }
+        .running { background: #d4edda; color: #155724; }
+        .stopped { background: #f8d7da; color: #721c24; }
+    </style>
+</head>
+<body>
+    <h1>🎭 Claude Conductor - Simple Mode</h1>
+    
+    <div class=\"card\">
+        <h3>📊 System Status</h3>
+        <div class=\"status stopped\">⚫ Simplified Demo Mode</div>
+        <p>This is a simplified demonstration version.</p>
+    </div>
+    
+    <div class=\"card\">
+        <h3>🚀 Quick Actions</h3>
+        <button class=\"button\" onclick=\"alert(\'Feature available in full version\')\">Start Task</button>
+        <button class=\"button\" onclick=\"alert(\'Feature available in full version\')\">View Logs</button>
+    </div>
+    
+    <div class=\"card\">
+        <h3>📝 Sample Tasks</h3>
+        <ul>
+            <li>echo \"Hello from Claude Conductor!\"</li>
+            <li>python3 -c \"print(\'System test successful\')\"</li>
+            <li>ls -la && pwd</li>
+        </ul>
+    </div>
+    
+    <div class=\"card\">
+        <h3>🔗 Next Steps</h3>
+        <p>For full functionality, please use the complete installation:</p>
+        <pre>git clone https://github.com/ootakazuhiko/claude-conductor.git
+cd claude-conductor
+git checkout feature/standalone-subset
+./quick-start.sh</pre>
+    </div>
+</body>
+</html>
+'''
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(html_content.encode())
+
+print(f'Starting server on port {PORT}...')
+with socketserver.TCPServer(('', PORT), Handler) as httpd:
+    def open_browser():
+        time.sleep(1)
+        webbrowser.open(f'http://localhost:{PORT}')
+    
+    threading.Thread(target=open_browser, daemon=True).start()
+    
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print('\nShutting down...')
+        httpd.shutdown()
+"
+EOF
+
+chmod +x run.sh
+
+# 完了メッセージ
+echo -e "${GREEN}✅ Simple setup completed!${NC}"
+echo ""
+echo -e "${YELLOW}🚀 To start:${NC}"
+echo "   cd $SETUP_DIR"
+echo "   ./run.sh"
+echo ""
+echo -e "${YELLOW}🌐 Dashboard:${NC} http://localhost:8080"
+echo ""
+echo -e "${YELLOW}📝 Note:${NC} This is a demo version."
+echo "   For full functionality, use ./quick-start.sh"


### PR DESCRIPTION
## 概要

単一PCで手軽にClaude Conductorを導入できるサブセット版を追加しました。

## 変更内容

### 🚀 新機能

1. **ワンコマンドインストール**
   - `quick-start.sh` - 5分で完了する自動セットアップ
   - `simple-setup.sh` - 超軽量デモ版

2. **軽量設定**
   - 最小メモリ2GB、推奨4GB
   - エージェント数1-4（設定可能）
   - 複雑な依存関係を排除

3. **簡易Docker展開**
   - `docker-compose.standalone.yml` - 単一マシン向け構成
   - オプションのRedis/ファイルサーバー

4. **包括的ドキュメント**
   - 日本語クイックスタートガイド
   - 実践的なサンプルコード
   - トラブルシューティングガイド

5. **アーキテクチャ図**
   - Standalone/Docker/Kubernetes比較
   - デプロイメント進化パス
   - 意思決定ガイド

## 動作確認

- [ ] `./quick-start.sh` でインストール成功
- [ ] `conductor start` でシステム起動
- [ ] http://localhost:8080 でダッシュボード表示
- [ ] `conductor test` でテスト実行成功
- [ ] Docker Composeでの起動確認

## スクリーンショット

```
🎭 Claude Conductor - Standalone
==================================
✅ Installation completed!
==================================

🚀 Quick Start:
   cd ~/.claude-conductor
   ./conductor start

🌐 Dashboard: http://localhost:8080
📖 Documentation: ~/.claude-conductor/README.md
⚙️  Configuration: ~/.claude-conductor/config/config.yaml
```

## 使用方法

```bash
# インストール
git checkout feature/standalone-subset
./quick-start.sh

# 起動
conductor start

# ダッシュボード
conductor dashboard
```

## 本番版との違い

| 機能 | Standalone | Production |
|------|-----------|------------|
| セットアップ時間 | 5分 | 30分+ |
| 必要スキル | 基本的なCLI | K8s経験 |
| エージェント数 | 1-4 | 無制限 |
| 高可用性 | ❌ | ✅ |
| 自動スケーリング | ❌ | ✅ |

## メリット

- **学習コストが低い**: 5分で試せる
- **リソース効率**: 最小2GB RAMで動作
- **移行パス**: 本番版への段階的移行が可能
- **開発に最適**: ローカル開発環境として利用

## レビューポイント

1. インストールスクリプトの動作確認
2. ドキュメントの分かりやすさ
3. デフォルト設定の妥当性
4. エラーハンドリング

## 関連Issue

- N/A（新機能）

## チェックリスト

- [x] コードはlintを通過
- [x] テストを追加/更新
- [x] ドキュメントを更新
- [x] CHANGELOG.mdを更新（必要に応じて）
- [x] 破壊的変更なし